### PR TITLE
feat: mpt parent branch node conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5181,6 +5181,7 @@ dependencies = [
  "reth-primitives",
  "reth-trie",
  "revm-primitives",
+ "rsp-primitives",
  "tracing-subscriber",
 ]
 
@@ -5227,6 +5228,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-errors",
  "revm-primitives",
+ "rsp-primitives",
  "serde",
 ]
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ cd ../guest-op
 cargo prove build
 ```
 
+## RPC node requirement
+
+In certain cases, the host needs to recover the preimage of a [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/) node that's referenced by hash. To do this, the host utilizes the [`debug_dbGet` endpoint](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugdbget) of a Geth node running with options `--state.scheme=hash`, which is the default, and `--gcmode=archive`.
+
+Therefore, when running the host CLI or integration tests, make sure to use an RPC URL pointing to a Geth node running with said options, or errors will arise when preimage recovery is needed.
+
 ## Run
 
 The host CLI automatically identifies the underlying chain type based on chain ID. Simply suppply a block number and an RPC URL to run the `rps-host` target:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,16 @@ cd ../guest-op
 cargo prove build
 ```
 
-## RPC node requirement
+## RPC Node Requirement
 
-In certain cases, the host needs to recover the preimage of a [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/) node that's referenced by hash. To do this, the host utilizes the [`debug_dbGet` endpoint](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugdbget) of a Geth node running with options `--state.scheme=hash`, which is the default, and `--gcmode=archive`.
+In certain cases, the host needs to recover the preimage of a [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/) node that's referenced by hash. To do this, the host utilizes the [`debug_dbGet` endpoint](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugdbget) of a Geth node running with options `--state.scheme=hash`, which is the default, and `--gcmode=archive`. An example command for running the node would be:
+
+```bash
+geth \
+  --gcmode=archive \
+  --http \
+  --http.api=eth,debug
+```
 
 Therefore, when running the host CLI or integration tests, make sure to use an RPC URL pointing to a Geth node running with said options, or errors will arise when preimage recovery is needed.
 

--- a/bin/guest-eth/Cargo.lock
+++ b/bin/guest-eth/Cargo.lock
@@ -2825,6 +2825,7 @@ dependencies = [
  "reth-primitives",
  "reth-trie",
  "revm-primitives",
+ "rsp-primitives",
 ]
 
 [[package]]
@@ -2850,6 +2851,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-errors",
  "revm-primitives",
+ "rsp-primitives",
  "serde",
 ]
 

--- a/bin/guest-op/Cargo.lock
+++ b/bin/guest-op/Cargo.lock
@@ -2825,6 +2825,7 @@ dependencies = [
  "reth-primitives",
  "reth-trie",
  "revm-primitives",
+ "rsp-primitives",
 ]
 
 [[package]]
@@ -2850,6 +2851,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-errors",
  "revm-primitives",
+ "rsp-primitives",
  "serde",
 ]
 

--- a/crates/executor/guest/src/lib.rs
+++ b/crates/executor/guest/src/lib.rs
@@ -60,7 +60,7 @@ impl GuestExecutor {
     {
         // Initialize the witnessed database with verified storage proofs.
         let witness_db = input.witness_db()?;
-        let cache_db = CacheDB::new(witness_db);
+        let cache_db = CacheDB::new(&witness_db);
 
         // Execute the block.
         let spec = V::spec();
@@ -104,7 +104,7 @@ impl GuestExecutor {
 
         // Verify the state root.
         let state_root = profile!("compute state root", {
-            rsp_mpt::compute_state_root(&executor_outcome, &input.dirty_storage_proofs)
+            rsp_mpt::compute_state_root(&executor_outcome, &input.dirty_storage_proofs, &witness_db)
         })?;
         if state_root != input.current_block.state_root {
             eyre::bail!("mismatched state root");

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -150,7 +150,8 @@ impl<T: Transport + Clone, P: Provider<T> + Clone> HostExecutor<T, P> {
 
         // Verify the state root.
         tracing::info!("verifying the state root");
-        let state_root = rsp_mpt::compute_state_root(&executor_outcome, &dirty_storage_proofs)?;
+        let state_root =
+            rsp_mpt::compute_state_root(&executor_outcome, &dirty_storage_proofs, &rpc_db)?;
         if state_root != current_block.state_root {
             eyre::bail!("mismatched state root");
         }
@@ -190,6 +191,7 @@ impl<T: Transport + Clone, P: Provider<T> + Clone> HostExecutor<T, P> {
             dirty_storage_proofs,
             used_storage_proofs: rpc_db.fetch_used_accounts_and_proofs().await,
             block_hashes: rpc_db.block_hashes.borrow().clone(),
+            trie_nodes: rpc_db.trie_nodes.borrow().values().cloned().collect(),
         };
         Ok(guest_input)
     }

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -14,6 +14,9 @@ workspace = true
 eyre.workspace = true
 itertools = "0.13.0"
 
+# workspace
+rsp-primitives.workspace = true
+
 # reth
 reth-primitives.workspace = true
 reth-trie.workspace = true

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -12,13 +12,18 @@ use reth_trie::{
     EMPTY_ROOT_HASH,
 };
 use revm_primitives::{keccak256, HashMap};
+use rsp_primitives::storage::ExtDatabaseRef;
 
 /// Computes the state root of a block's Merkle Patricia Trie given an [ExecutionOutcome] and a list
 /// of [EIP1186AccountProofResponse] storage proofs.
-pub fn compute_state_root(
+pub fn compute_state_root<DB>(
     execution_outcome: &ExecutionOutcome,
     storage_proofs: &[AccountProof],
-) -> eyre::Result<B256> {
+    db: &DB,
+) -> eyre::Result<B256>
+where
+    DB: ExtDatabaseRef<Error: std::fmt::Debug>,
+{
     // Reconstruct prefix sets manually to record pre-images for subsequent lookups.
     let mut hashed_state = HashedPostState::default();
     let mut account_reverse_lookup = HashMap::<B256, Address>::default();
@@ -28,12 +33,10 @@ pub fn compute_state_root(
         account_reverse_lookup.insert(hashed_address, address);
         hashed_state.accounts.insert(hashed_address, account.info.clone().map(Into::into));
 
-        let mut storage_keys = Vec::new();
         let mut hashed_storage = HashedStorage::new(account.status.was_destroyed());
         for (key, value) in &account.storage {
             let slot = B256::new(key.to_be_bytes());
             let hashed_slot = keccak256(slot);
-            storage_keys.push(slot);
             storage_reverse_lookup.insert(hashed_slot, slot);
             hashed_storage.storage.insert(hashed_slot, value.present_value);
         }
@@ -55,50 +58,61 @@ pub fn compute_state_root(
         let root = if proof.storage_proofs.is_empty() {
             proof.storage_root
         } else {
-            compute_root_from_proofs(storage_prefix_sets.freeze().iter().map(|storage_nibbles| {
-                let hashed_slot = B256::from_slice(&storage_nibbles.pack());
-                let slot = storage_reverse_lookup.get(&hashed_slot).unwrap();
-                let storage_proof = proof.storage_proofs.iter().find(|x| x.key.0 == slot).unwrap();
-                let encoded = Some(
-                    hashed_state
-                        .storages
-                        .get(&hashed_address)
-                        .and_then(|s| s.storage.get(&hashed_slot).cloned())
-                        .unwrap_or_default(),
-                )
-                .filter(|v| !v.is_zero())
-                .map(|v| alloy_rlp::encode_fixed_size(&v).to_vec());
-                (storage_nibbles.clone(), encoded, storage_proof.proof.clone())
-            }))?
+            compute_root_from_proofs(
+                storage_prefix_sets.freeze().iter().map(|storage_nibbles| {
+                    let hashed_slot = B256::from_slice(&storage_nibbles.pack());
+                    let slot = storage_reverse_lookup.get(&hashed_slot).unwrap();
+                    let storage_proof =
+                        proof.storage_proofs.iter().find(|x| x.key.0 == slot).unwrap();
+                    let encoded = Some(
+                        hashed_state
+                            .storages
+                            .get(&hashed_address)
+                            .and_then(|s| s.storage.get(&hashed_slot).cloned())
+                            .unwrap_or_default(),
+                    )
+                    .filter(|v| !v.is_zero())
+                    .map(|v| alloy_rlp::encode_fixed_size(&v).to_vec());
+                    (storage_nibbles.clone(), encoded, storage_proof.proof.clone())
+                }),
+                db,
+            )?
         };
         storage_roots.insert(hashed_address, root);
     }
 
     // Compute the state root of the entire trie.
     let mut rlp_buf = Vec::with_capacity(128);
-    compute_root_from_proofs(account_prefix_set.iter().map(|account_nibbles| {
-        let hashed_address = B256::from_slice(&account_nibbles.pack());
-        let address = *account_reverse_lookup.get(&hashed_address).unwrap();
-        let proof = storage_proofs.iter().find(|x| x.address == address).unwrap();
+    compute_root_from_proofs(
+        account_prefix_set.iter().map(|account_nibbles| {
+            let hashed_address = B256::from_slice(&account_nibbles.pack());
+            let address = *account_reverse_lookup.get(&hashed_address).unwrap();
+            let proof = storage_proofs.iter().find(|x| x.address == address).unwrap();
 
-        let storage_root = *storage_roots.get(&hashed_address).unwrap();
+            let storage_root = *storage_roots.get(&hashed_address).unwrap();
 
-        let account = hashed_state.accounts.get(&hashed_address).unwrap().unwrap_or_default();
-        let encoded = if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
-            None
-        } else {
-            rlp_buf.clear();
-            TrieAccount::from((account, storage_root)).encode(&mut rlp_buf);
-            Some(rlp_buf.clone())
-        };
-        (account_nibbles.clone(), encoded, proof.proof.clone())
-    }))
+            let account = hashed_state.accounts.get(&hashed_address).unwrap().unwrap_or_default();
+            let encoded = if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
+                None
+            } else {
+                rlp_buf.clear();
+                TrieAccount::from((account, storage_root)).encode(&mut rlp_buf);
+                Some(rlp_buf.clone())
+            };
+            (account_nibbles.clone(), encoded, proof.proof.clone())
+        }),
+        db,
+    )
 }
 
 /// Given a list of Merkle-Patricia proofs, compute the root of the trie.
-fn compute_root_from_proofs(
+fn compute_root_from_proofs<DB>(
     items: impl IntoIterator<Item = (Nibbles, Option<Vec<u8>>, Vec<Bytes>)>,
-) -> eyre::Result<B256> {
+    db: &DB,
+) -> eyre::Result<B256>
+where
+    DB: ExtDatabaseRef<Error: std::fmt::Debug>,
+{
     let mut trie_nodes = BTreeMap::default();
 
     for (key, value, proof) in items {
@@ -169,7 +183,7 @@ fn compute_root_from_proofs(
     let mut hash_builder = HashBuilder::default();
     let mut trie_nodes =
         trie_nodes.into_iter().filter(|(path, _)| !ignored_keys.contains(path)).peekable();
-    while let Some((path, value)) = trie_nodes.next() {
+    while let Some((mut path, value)) = trie_nodes.next() {
         match value {
             Either::Left(branch_hash) => {
                 let parent_branch_path = path.slice(..path.len() - 1);
@@ -180,8 +194,49 @@ fn compute_root_from_proofs(
                 {
                     hash_builder.add_branch(path, branch_hash, false);
                 } else {
-                    // parent is a branch node that needs to be turned into extension
-                    todo!()
+                    // Parent was a branch node but now all but one children are gone. We
+                    // technically have to modify this branch node, but the `alloy-trie` hash
+                    // builder handles this automatically when supplying child nodes.
+
+                    let preimage = db.trie_node_ref(branch_hash).unwrap();
+                    match TrieNode::decode(&mut &preimage[..]).unwrap() {
+                        TrieNode::Branch(_) => {
+                            // This node is a branch node that's referenced by hash. There's no need
+                            // to handle the content as the node itself is unchanged.
+                            hash_builder.add_branch(path, branch_hash, false);
+                        }
+                        TrieNode::Extension(extension) => {
+                            // This node is an extension node. Simply prepend the leaf node's key
+                            // with the original branch index. `alloy-trie` automatically handles
+                            // this so we only have to reconstruct the full key path.
+                            path.extend_from_slice(&extension.key);
+
+                            // In theory, it's possible that this extension node's child branch is
+                            // encoded in-place, though it should be extremely rare, as for that to
+                            // happen, at least 2 storage nodes must share a very long prefix, which
+                            // is very unlikely to happen given that they're hashes.
+                            //
+                            // Moreover, `alloy-trie` currently does not offer an API for this rare
+                            // case anyway. See relevant (but not directly related) PR:
+                            //
+                            // https://github.com/alloy-rs/trie/pull/27
+                            if extension.child.len() == B256::len_bytes() + 1 {
+                                hash_builder.add_branch(
+                                    path,
+                                    B256::from_slice(&extension.child[1..]),
+                                    false,
+                                );
+                            } else {
+                                todo!("handle in-place extension child")
+                            }
+                        }
+                        TrieNode::Leaf(leaf) => {
+                            // Same as the extension node's case: we only have to reconstruct the
+                            // full path.
+                            path.extend_from_slice(&leaf.key);
+                            hash_builder.add_leaf(path, &leaf.value);
+                        }
+                    }
                 }
             }
             Either::Right(leaf_value) => {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod account_proof;
 pub mod chain_spec;
+pub mod storage;

--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -1,0 +1,10 @@
+use reth_primitives::{Bytes, B256};
+
+/// Custom database access methods implemented by RSP storage backends.
+pub trait ExtDatabaseRef {
+    /// The database error type.
+    type Error;
+
+    /// Gets the preimage of a trie node given its Keccak hash.
+    fn trie_node_ref(&self, hash: B256) -> Result<Bytes, Self::Error>;
+}

--- a/crates/storage/witness-db/Cargo.toml
+++ b/crates/storage/witness-db/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [dependencies]
 serde.workspace = true
 
+# workspace
+rsp-primitives.workspace = true
+
 # reth
 reth-primitives.workspace = true
 reth-storage-errors.workspace = true


### PR DESCRIPTION
Fixes #6.

Implements the missing Merkle Patricia Trie code path:

https://github.com/succinctlabs/rsp/blob/52b27c894e29ff488038c7e698474cba739f354e/crates/mpt/src/lib.rs#L183-L184

This implementation makes use of the Geth-specific `debug_dbGet` method for preimage recovery. Also adds instructions to README specifying the Geth node requirement.