### PR TITLE
fix: incorrect handling of in-place trie nodes

### DIFF
--- a/bin/guest-eth/Cargo.lock
+++ b/bin/guest-eth/Cargo.lock
@@ -328,8 +328,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
+source = "git+https://github.com/xJonathanLEI/trie.git?rev=fb57b642278fd4213f244a2ab217be831a51abc9#fb57b642278fd4213f244a2ab217be831a51abc9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/guest-eth/Cargo.toml
+++ b/bin/guest-eth/Cargo.toml
@@ -19,3 +19,6 @@ sp1-zkvm = "1.0.1"
 alloy-eips = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 alloy-serde = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+
+# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
+alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }

--- a/bin/guest-op/Cargo.lock
+++ b/bin/guest-op/Cargo.lock
@@ -328,8 +328,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
+source = "git+https://github.com/xJonathanLEI/trie.git?rev=fb57b642278fd4213f244a2ab217be831a51abc9#fb57b642278fd4213f244a2ab217be831a51abc9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/guest-op/Cargo.toml
+++ b/bin/guest-op/Cargo.toml
@@ -19,3 +19,6 @@ sp1-zkvm = "1.0.1"
 alloy-eips = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 alloy-serde = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+
+# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
+alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }


### PR DESCRIPTION
Fixes an issue of panicking when computing state root due to trie nodes being encoded in-place. This can happen when the common prefix is long enough and the storage value is small enough.

An Optimism block for testing is `123955997`, which panics without this patch.