### PR TITLE
fix: state root mismatch when deleting multiple branch children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,6 +5200,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "eyre",
+ "hex-literal",
  "itertools 0.13.0",
  "reth-execution-types",
  "reth-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0", default-features = false }
 futures = "0.3"
 url = "2.3"
 thiserror = "1.0.61"
+hex-literal = "0.4.1"
 
 # workspace
 rsp-rpc-db = { path = "./crates/storage/rpc-db" }

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -31,4 +31,5 @@ alloy-rlp.workspace = true
 alloy-rpc-types.workspace = true
 
 [dev-dependencies]
+hex-literal.workspace = true
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
Fixes a bug in root hash building when multiple child nodes in a branch are deleted at the same time. This happens frequently on Ethereum, as the incentives for clearing storage slots are stronger compared to L2 networks.

The root cause is that the existing code assumes that when walking a proof, all neighbours will always end up being part of the final trie. This only works when at most one child node is being deleted by the trie, but quickly falls apart when multiple nodes are deleted, as each proof walking includes the other deleted path, resulting in both nodes ending up in the final trie.

This PR also sets up testing for the `rsp-mpt` crate, with hand-crafted test tries specifically targeting this bug. Future bug fixes shall also be accompanied by tests.

A real-world Ethereum block that failed to execute due to this bug is `20526648`.