### PR TITLE
fix: inserting node with updated neighbour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,8 +447,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
+source = "git+https://github.com/xJonathanLEI/trie.git?rev=fb57b642278fd4213f244a2ab217be831a51abc9#fb57b642278fd4213f244a2ab217be831a51abc9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5202,6 +5201,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "alloy-trie",
  "eyre",
  "hex-literal",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,12 +134,18 @@ alloy-transport-http = { version = "0.1", features = [
 ], default-features = false }
 alloy-eips = { version = "0.1", default-features = false }
 
+# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
+alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }
+
 [patch.crates-io]
 # alloy-eips = { path = "../alloy/crates/eips" }
 # alloy-serde = { path = "../alloy/crates/serde" }
 alloy-eips = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 alloy-serde = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+
+# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
+alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -31,5 +31,6 @@ alloy-rlp.workspace = true
 alloy-rpc-types.workspace = true
 
 [dev-dependencies]
+alloy-trie.workspace = true
 hex-literal.workspace = true
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
Fixes a state root computation edge case that involves inserting a new trie node that happens to have an immediate lower neighbour whose value is being updated.

When proving the absence of a node (and hence an insertion), there are cases where instead of proving a dead end on the parent branch, a neighbour node is proven instead. This happens when the neighbour node shares the same extra prefix with the node being inserted. Consider this simple trie:

- node path: `11a`
- node path: `2a`

Before any insertion, the root node is a branch node with children at slot `1` and `2`, both of which are leaf nodes.

Now, consider inserting `12b`. In order to prove its previous absence, the proof would contain the root branch node and the preimage of `11a` to show that while the slot `1` fits the new node, it actually points to the path of `11` instead of `12`, and thus proving the absence of the new node.

When walking the proof for `12b`, the current implementation always collects everything alongside the proof, including the `11a` preimage that's included solely to prove the absence of `12b`.

There's only one problem: the proof for `12b` contains the *old* value of the `11a`. If `11a` itself is updated and its proof is walked *before* `12b`, then its updated value gets overwritten.

The fix is simple: when walking a proof and collecting neighbour nodes, do not overwrite if there's already a value set. It might have been set by a previous neighbour collection but that's fine as walking `11a` always overwrites it.

A new test case has been added to accompany the fix. A real world Ethereum mainnet block affected is `20526020`.