### PR TITLE
chore: replace `alloy-rs/trie` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.4.1"
-source = "git+https://github.com/xJonathanLEI/trie.git?rev=fb57b642278fd4213f244a2ab217be831a51abc9#fb57b642278fd4213f244a2ab217be831a51abc9"
+source = "git+https://github.com/alloy-rs/trie.git?rev=28ebb7cc70cbef9e894e5b36c99e28412525ac1a#28ebb7cc70cbef9e894e5b36c99e28412525ac1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,8 +134,8 @@ alloy-transport-http = { version = "0.1", features = [
 ], default-features = false }
 alloy-eips = { version = "0.1", default-features = false }
 
-# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
-alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }
+# Using GitHub until https://github.com/alloy-rs/trie/pull/27 is released
+alloy-trie = { git = "https://github.com/alloy-rs/trie.git", rev = "28ebb7cc70cbef9e894e5b36c99e28412525ac1a" }
 
 [patch.crates-io]
 # alloy-eips = { path = "../alloy/crates/eips" }
@@ -144,8 +144,8 @@ alloy-eips = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp
 alloy-serde = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 
-# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
-alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }
+# Using GitHub until https://github.com/alloy-rs/trie/pull/27 is released
+alloy-trie = { git = "https://github.com/alloy-rs/trie.git", rev = "28ebb7cc70cbef9e894e5b36c99e28412525ac1a" }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.4.1"
-source = "git+https://github.com/xJonathanLEI/trie.git?rev=fb57b642278fd4213f244a2ab217be831a51abc9#fb57b642278fd4213f244a2ab217be831a51abc9"
+source = "git+https://github.com/alloy-rs/trie.git?rev=28ebb7cc70cbef9e894e5b36c99e28412525ac1a#28ebb7cc70cbef9e894e5b36c99e28412525ac1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -19,8 +19,8 @@ sp1-zkvm = { git = "https://github.com/succinctlabs/sp1", branch = "experimental
 alloy-eips = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 alloy-serde = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 
-# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
-alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }
+# Using GitHub until https://github.com/alloy-rs/trie/pull/27 is released
+alloy-trie = { git = "https://github.com/alloy-rs/trie.git", rev = "28ebb7cc70cbef9e894e5b36c99e28412525ac1a" }
 
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.4.1"
-source = "git+https://github.com/xJonathanLEI/trie.git?rev=fb57b642278fd4213f244a2ab217be831a51abc9#fb57b642278fd4213f244a2ab217be831a51abc9"
+source = "git+https://github.com/alloy-rs/trie.git?rev=28ebb7cc70cbef9e894e5b36c99e28412525ac1a#28ebb7cc70cbef9e894e5b36c99e28412525ac1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -19,9 +19,8 @@ sp1-zkvm = { git = "https://github.com/succinctlabs/sp1", branch = "experimental
 alloy-eips = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 alloy-serde = { git = "https://github.com/jtguibas/alloy.git", branch = "john/rsp-8e9e6ac" }
 
-# Using the fork until https://github.com/alloy-rs/trie/pull/27 is merged and released
-alloy-trie = { git = "https://github.com/xJonathanLEI/trie.git", rev = "fb57b642278fd4213f244a2ab217be831a51abc9" }
-
+# Using GitHub until https://github.com/alloy-rs/trie/pull/27 is released
+alloy-trie = { git = "https://github.com/alloy-rs/trie.git", rev = "28ebb7cc70cbef9e894e5b36c99e28412525ac1a" }
 
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }


### PR DESCRIPTION
https://github.com/alloy-rs/trie/pull/27 has been merged and there's no reason to use a fork anymore. When it gets released on we can further switch back to crates.io.