### PR TITLE
perf: use only parent header for input

### DIFF
--- a/crates/executor/client/src/io.rs
+++ b/crates/executor/client/src/io.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use eyre::Result;
-use reth_primitives::{revm_primitives::AccountInfo, Address, Block, Bytes, B256, U256};
+use reth_primitives::{revm_primitives::AccountInfo, Address, Block, Bytes, Header, B256, U256};
 use reth_trie::AccountProof;
 use revm_primitives::keccak256;
 use rsp_primitives::account_proof::AccountProofWithBytecode;
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 pub struct ClientExecutorInput {
     /// The current block (which will be executed inside the client).
     pub current_block: Block,
-    /// The previous block.
-    pub previous_block: Block,
+    /// The previous block header.
+    pub previous_block: Header,
     /// The dirty storage proofs for the storage slots that were modified.
     pub dirty_storage_proofs: Vec<AccountProof>,
     /// The storage proofs for the storage slots that were accessed.

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -179,7 +179,7 @@ impl<T: Transport + Clone, P: Provider<T> + Clone> HostExecutor<T, P> {
 
         // Create the client input.
         let client_input = ClientExecutorInput {
-            previous_block,
+            previous_block: previous_block.header,
             current_block,
             dirty_storage_proofs,
             used_storage_proofs: rpc_db.fetch_used_accounts_and_proofs().await,


### PR DESCRIPTION
The client only ever needs the state root and header hash. There's no reason to pass in the whole parent block.

Tested on block `20600000` over 5 runs yielding an average of `762,187,948` cycles, slightly down from `762,727,324` on current `main` (378ccee).