### PR TITLE
chore: resume state root assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal implementation of generating zero-knowledge proofs of EVM block execut
 
 > [!CAUTION]
 >
-> This repository is still an active work-in-progress and is not audited or meant for production usage. In particular, there are some edge cases in Ethereum state root computation due to complications with the Merkle Patricia Trie (MPT) that result in the state root computation being slightly incorrect (we're actively working on fixing this). However, the prover time should still be an accurate estimate of proving costs in practice.
+> This repository is still an active work-in-progress and is not audited or meant for production usage.
 
 ## Getting Started
 
@@ -134,10 +134,6 @@ To build the Optimism client ELF program:
 cd ./bin/client-op
 cargo prove build
 ```
-
-**Why does the program say "The state root doesn't match"?**
-
-As mentioned in the introduction, this repository is still a work in progress and some edge cases in the Ethereum MPT result in the state root computation being slightly incorrect for certain blocks. We're actively working on fixing this, but running these client programs on Ethereum and Optimism blocks still provides a very good estimate of realistic cycle count and proving workloads.
 
 **What are good testing blocks**
 

--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -135,10 +135,7 @@ impl ClientExecutor {
             rsp_mpt::compute_state_root(&executor_outcome, &input.dirty_storage_proofs, &witness_db)
         })?;
         if state_root != input.current_block.state_root {
-            // TODO: comment this check back in, but leaving it out for now so that we can
-            // get rough cycle counts.
-            println!("The state root doesn't match.");
-            // eyre::bail!("mismatched state root");
+            eyre::bail!("mismatched state root");
         }
 
         // Derive the block header.

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -143,10 +143,7 @@ impl<T: Transport + Clone, P: Provider<T> + Clone> HostExecutor<T, P> {
         let state_root =
             rsp_mpt::compute_state_root(&executor_outcome, &dirty_storage_proofs, &rpc_db)?;
         if state_root != current_block.state_root {
-            // TODO: comment this check back in, but leaving it out for now so that we can
-            // get rough cycle counts.
-            println!("The state root doesn't match.");
-            // eyre::bail!("mismatched state root");
+            eyre::bail!("mismatched state root");
         }
 
         // Derive the block header.


### PR DESCRIPTION
After multiple MPT bug fix PRs, the code has now been tested against Ethereum  blocks `20527000` to `20577000` and beyond, for more than 50,000k blocks without encountering any MPT issue at all. It's safe to at least resume the assertion as it's nice to make it more obvious a state root issue has happened.