### PR TITLE
test: integration test for Linea

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 RPC_1=
 RPC_10=
+RPC_59144=
 
 # environment variables for prover network
 SP1_PROVER=network

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: "Set up test fixture"
         run: |
-          git clone https://github.com/succinctlabs/rsp-tests --branch 2024-08-26 --depth 1 ../rsp-tests
+          git clone https://github.com/succinctlabs/rsp-tests --branch 2024-08-31 --depth 1 ../rsp-tests
           cd ../rsp-tests/
           docker compose up -d
 
@@ -63,6 +63,7 @@ jobs:
         run: |
           echo "RPC_1=http://localhost:9545/main/evm/1" >> $GITHUB_ENV
           echo "RPC_10=http://localhost:9545/main/evm/10" >> $GITHUB_ENV
+          echo "RPC_59144=http://localhost:9545/main/evm/59144" >> $GITHUB_ENV
 
       - name: "Run tests"
         run: |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ End-to-end integration tests are available. To run these tests, utilize the `.en
 ```bash
 export RPC_1="YOUR_ETHEREUM_MAINNET_RPC_URL"
 export RPC_10="YOUR_OP_MAINNET_RPC_URL"
+export RPC_59144="YOUR_LINEA_MAINNET_RPC_URL"
 ```
 
 Note that these JSON-RPC nodes must fulfill the [RPC node requirement](#rpc-node-requirement).

--- a/crates/executor/host/tests/integration.rs
+++ b/crates/executor/host/tests/integration.rs
@@ -1,7 +1,7 @@
 use alloy_provider::ReqwestProvider;
 use rsp_client_executor::{
-    io::ClientExecutorInput, ChainVariant, ClientExecutor, EthereumVariant, OptimismVariant,
-    Variant,
+    io::ClientExecutorInput, ChainVariant, ClientExecutor, EthereumVariant, LineaVariant,
+    OptimismVariant, Variant,
 };
 use rsp_host_executor::HostExecutor;
 use tracing_subscriber::{
@@ -17,6 +17,11 @@ async fn test_e2e_ethereum() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_optimism() {
     run_e2e::<OptimismVariant>(ChainVariant::Optimism, "RPC_10", 122853660).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_e2e_linea() {
+    run_e2e::<LineaVariant>(ChainVariant::Linea, "RPC_59144", 5600000).await;
 }
 
 async fn run_e2e<V>(variant: ChainVariant, env_var_key: &str, block_number: u64)


### PR DESCRIPTION
Adds integration test for Linea using the [updated](https://github.com/succinctlabs/rsp-tests/commit/9e76bc0d5eca334622cef3529df7ec9038033716) `rsp-tests` cache that now includes a [Linea mainnet block](https://github.com/succinctlabs/rsp-tests/blob/9e76bc0d5eca334622cef3529df7ec9038033716/blocks.json#L13).