### PR TITLE
perf: statically disable logging in clients

### DIFF
--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -2584,8 +2584,10 @@ name = "rsp-client-eth"
 version = "0.0.0"
 dependencies = [
  "bincode",
+ "log",
  "rsp-client-executor",
  "sp1-zkvm",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -13,6 +13,10 @@ rsp-client-executor = { path = "../../crates/executor/client" }
 # sp1
 sp1-zkvm = "1.2.0-rc2"
 
+# Statically turns off logging
+log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
+tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -2616,8 +2616,10 @@ name = "rsp-client-linea"
 version = "0.0.0"
 dependencies = [
  "bincode",
+ "log",
  "rsp-client-executor",
  "sp1-zkvm",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/client-linea/Cargo.toml
+++ b/bin/client-linea/Cargo.toml
@@ -13,6 +13,10 @@ rsp-client-executor = { path = "../../crates/executor/client" }
 # sp1
 sp1-zkvm = "1.2.0-rc2"
 
+# Statically turns off logging
+log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
+tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -2616,8 +2616,10 @@ name = "rsp-client-op"
 version = "0.0.0"
 dependencies = [
  "bincode",
+ "log",
  "rsp-client-executor",
  "sp1-zkvm",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -13,6 +13,10 @@ rsp-client-executor = { path = "../../crates/executor/client" }
 # sp1
 sp1-zkvm = "1.2.0-rc2"
 
+# Statically turns off logging
+log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
+tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }


### PR DESCRIPTION
Some dependencies are instrumented with logging, and the log level evaluation happens at runtime. While the client programs don't actually print any logs to the output, such evaluation still happens silently and costs cycles. This PR disables logging at compile time to completely eliminates them from the resulting binary.

Performance improves slightly. For the block tested of `20600000`, the cycle count drops from `769,074,912` to `759,763,136` by 1.22%.