### PR TITLE
fix: unconstrained block hashes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: "Set up test fixture"
         run: |
-          git clone https://github.com/succinctlabs/rsp-tests --branch 2024-09-09 --depth 1 ../rsp-tests
+          git clone https://github.com/succinctlabs/rsp-tests --branch 2024-09-11 --depth 1 ../rsp-tests
           cd ../rsp-tests/
           docker compose up -d
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,7 +5421,6 @@ dependencies = [
  "reth-trie",
  "revm-primitives",
  "rsp-primitives",
- "rsp-witness-db",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -158,7 +158,7 @@ impl ClientExecutor {
         //
         // Note: the receipts root and gas used are verified by `validate_block_post_execution`.
         let mut header = input.current_block.header.clone();
-        header.parent_hash = input.previous_block.hash_slow();
+        header.parent_hash = input.parent_header().hash_slow();
         header.ommers_hash = proofs::calculate_ommers_root(&input.current_block.ommers);
         header.state_root = input.current_block.state_root;
         header.transactions_root = proofs::calculate_transaction_root(&input.current_block.body);

--- a/crates/storage/rpc-db/Cargo.toml
+++ b/crates/storage/rpc-db/Cargo.toml
@@ -15,7 +15,6 @@ tracing.workspace = true
 rayon.workspace = true
 
 # workspace
-rsp-witness-db.workspace = true
 rsp-primitives.workspace = true
 
 # reth


### PR DESCRIPTION
Fixes an issue that allows arbitrary block hashes to be provided for the `BLOCKHASH` opcode to use. The new implementation uses a consecutive list of parent headers leading all the way to the oldest block whose hash has been requested.