### PR TITLE
chore: remove unnecessary use of nightly rust

### DIFF
--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(stmt_expr_attributes)]
-
 pub mod io;
 #[macro_use]
 pub mod utils;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2024-08-06"
-components = ["llvm-tools", "rustc-dev"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.81.0"
+components = ["rustfmt"]


### PR DESCRIPTION
Still pins toolchain for reproducibility though.