### PR TITLE
chore: remove unused patches

### DIFF
--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -3633,13 +3633,3 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
-
-[[patch.unused]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?branch=patch-v0.8.0#0c37e2976d3c55a5be5e5dd17e5aba444711ecd7"
-
-[[patch.unused]]
-name = "kzg-rs"
-version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kzg-rs?branch=bhargav/sp1-bls-patch#88aa8f1812619ab91f0fdfa744f161ae1604f76a"

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -23,5 +23,3 @@ sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "pat
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", branch = "patch-v0.8.0" }
-kzg-rs = { git = "https://github.com/succinctlabs/kzg-rs", branch = "bhargav/sp1-bls-patch" }

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -3633,13 +3633,3 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
-
-[[patch.unused]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?branch=patch-v0.8.0#0c37e2976d3c55a5be5e5dd17e5aba444711ecd7"
-
-[[patch.unused]]
-name = "kzg-rs"
-version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kzg-rs?branch=bhargav/sp1-bls-patch#88aa8f1812619ab91f0fdfa744f161ae1604f76a"

--- a/bin/client-linea/Cargo.toml
+++ b/bin/client-linea/Cargo.toml
@@ -23,5 +23,3 @@ sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "pat
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", branch = "patch-v0.8.0" }
-kzg-rs = { git = "https://github.com/succinctlabs/kzg-rs", branch = "bhargav/sp1-bls-patch" }

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -3633,13 +3633,3 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
-
-[[patch.unused]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?branch=patch-v0.8.0#0c37e2976d3c55a5be5e5dd17e5aba444711ecd7"
-
-[[patch.unused]]
-name = "kzg-rs"
-version = "0.1.0"
-source = "git+https://github.com/succinctlabs/kzg-rs?branch=bhargav/sp1-bls-patch#88aa8f1812619ab91f0fdfa744f161ae1604f76a"

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -23,5 +23,3 @@ sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "pat
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", branch = "patch-v0.8.0" }
-kzg-rs = { git = "https://github.com/succinctlabs/kzg-rs", branch = "bhargav/sp1-bls-patch" }


### PR DESCRIPTION
These patches are no longer needed as they've been merged and released to crates.io.