### PR TITLE
refactor: generic `WitnessInput` trait

### DIFF
--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -1,6 +1,7 @@
+/// Client program input data types.
 pub mod io;
 #[macro_use]
-pub mod utils;
+mod utils;
 
 pub mod custom;
 


### PR DESCRIPTION
Adds a zero-cost abstraction that allows downstream applications to build `WitnessDb` using their own client input types.