### PR TITLE
fix: meaningless block header hash matching

### DIFF
--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -52,7 +52,8 @@ impl<T: Transport + Clone, P: Provider<T, AnyNetwork> + Clone> HostExecutor<T, P
         let origin_current_block = self
             .provider
             .get_block_by_number(block_number.into(), true)
-            .await?.wrap_err(eyre!("couldn't fetch block: {}", block_number))?;
+            .await?
+            .ok_or_else(|| eyre!("couldn't fetch block: {}", block_number))?;
 
         let current_block = Block::try_from(origin_current_block.clone().inner)?;
 
@@ -187,7 +188,6 @@ impl<T: Transport + Clone, P: Provider<T, AnyNetwork> + Clone> HostExecutor<T, P
 
         // Assert the derived header is correct.
         assert_eq!(header.hash_slow(), origin_current_block.inner.header.hash, "header mismatch");
-        
         // Log the result.
         tracing::info!(
             "successfully executed block: block_number={}, block_hash={}, state_root={}",


### PR DESCRIPTION
The matching of Block Hash should be based on the result of RPC, for example, when facing rollup using clique, directly modifying the miner of block will lead to different final hash results. Because the miner in the program is not the same as the rpc.

Similarly, for a public chain like linear, miner needs to be modified in pre_process_block, and then miner needs to be reset in pre_finished_block (before comparing hashes).