### PR TITLE
perf: replace tiny-keccak with sha3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7198a527b4c4762cb88d54bcaeb0428f4298b72552c9c8ec4af614b4a4990c59"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -108,7 +108,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "serde",
 ]
@@ -119,7 +119,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "k256",
  "serde",
@@ -133,7 +133,7 @@ checksum = "159eab0e4e15b88571f55673af37314f4b8f17630dc1b393c3d70f2128a1d494"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -148,7 +148,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "210f4b358d724f85df8adaec753c583defb58169ad3cad3d48c80d1a25a6ff0e"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-serde",
  "serde",
 ]
@@ -159,7 +159,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "299d2a937b6c60968df3dad2a988b0f0e03277b344639a4f7a31bd68e6285e59"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -171,7 +171,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7733446dd531f8eb877331fea02f6c40bdbb47444a17dc3464bf75319cc073a"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-sol-types 0.8.0",
  "serde",
  "serde_json",
@@ -189,7 +189,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -206,7 +206,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76a2336889f3d0624b18213239d27f4f34eb476eb35bef22f6a8cc24e0c0078"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-serde",
  "serde",
 ]
@@ -235,24 +235,29 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767e59c86900dd7c3ce3ecef04f3ace5ac9631ee150beb8b7d22f7fa3bbb2d7"
+checksum = "0f778fe4183cecaec41361e65869e81e748c44a77fa3e6ba20219ca92be33a19"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "getrandom",
+ "hashbrown 0.14.5",
  "hex-literal",
+ "indexmap 2.5.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash 2.0.0",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -268,7 +273,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-transport",
@@ -353,7 +358,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types 0.8.0",
@@ -369,7 +374,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd260ede54f0b53761fdd04133acc10ae70427f66a69aa9590529bbd066cd58"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "serde",
  "serde_json",
 ]
@@ -380,7 +385,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5193ee6b370b89db154d7dc40c6a8e6ce11213865baaf2b418a9f2006be762"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "async-trait",
  "auto_impl",
  "elliptic-curve",
@@ -425,7 +430,7 @@ dependencies = [
  "alloy-sol-macro-input 0.7.7",
  "const-hex",
  "heck",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -443,7 +448,7 @@ dependencies = [
  "alloy-sol-macro-input 0.8.0",
  "const-hex",
  "heck",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -511,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577e262966e92112edbd15b1b2c0947cc434d6e8311df96d3329793fe8047da9"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-sol-macro 0.8.0",
  "const-hex",
  "serde",
@@ -557,7 +562,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd491aade72a82d51db430379f48a44a1d388ff03711a2023f1faa302c5b675d"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "derive_more 1.0.0",
  "hashbrown 0.14.5",
@@ -2587,7 +2592,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2606,7 +2611,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2970,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3609,7 +3614,7 @@ checksum = "a0db6e3a9bbbcef7cef19d77aa2cc76d61377376e3bb86f89167e7e3f30ea023"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -3623,7 +3628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c604cd3b9680d0edd0b7127f3550bcff634c2d2efe27b2b4853e72320186a8"
 dependencies = [
  "alloy-network",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "op-alloy-consensus",
@@ -4452,6 +4457,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -4696,7 +4702,7 @@ dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-trie",
  "auto_impl",
  "derive_more 1.0.0",
@@ -4718,7 +4724,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -4800,7 +4806,7 @@ version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "auto_impl",
  "crc",
@@ -4873,7 +4879,7 @@ version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "derive_more 1.0.0",
  "nybbles",
@@ -4910,7 +4916,7 @@ name = "reth-network-peers"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "enr 0.12.1",
  "serde_with",
@@ -4924,7 +4930,7 @@ version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "derive_more 1.0.0",
  "once_cell",
  "reth-chainspec",
@@ -4953,7 +4959,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-serde",
@@ -4983,7 +4989,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "byteorder",
@@ -5001,7 +5007,7 @@ name = "reth-prune-types"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
@@ -5030,7 +5036,7 @@ name = "reth-stages-types"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -5043,7 +5049,7 @@ name = "reth-static-file-types"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "derive_more 1.0.0",
  "serde",
  "strum",
@@ -5102,7 +5108,7 @@ source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-trie",
  "bytes",
@@ -5167,7 +5173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ccb981ede47ccf87c68cebf1ba30cdbb7ec935233ea305f3dfff4c1e10ae541"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "auto_impl",
  "bitflags 2.6.0",
  "bitvec",
@@ -5299,7 +5305,7 @@ dependencies = [
 name = "rsp-client-executor"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "eyre",
  "futures",
@@ -5331,7 +5337,7 @@ dependencies = [
 name = "rsp-host-executor"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
@@ -5367,7 +5373,7 @@ dependencies = [
 name = "rsp-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.0",
+ "alloy-primitives 0.8.4",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-trie",
@@ -5484,6 +5490,9 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -5792,7 +5801,7 @@ version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5840,7 +5849,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6975,7 +6984,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6986,7 +6995,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6997,7 +7006,7 @@ version = "0.22.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ revm-primitives = { version = "9.0.0", features = [
 revm-inspectors = "0.6"
 
 # alloy
-alloy-primitives = "0.8.0"
+alloy-primitives = { version = "0.8.4", features = ["sha3-keccak"] }
 alloy-provider = { version = "0.3", default-features = false, features = [
     "reqwest",
     "reqwest-rustls-tls",

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -183,8 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
-source = "git+https://github.com/alloy-rs/core?rev=9867b55a032a355b2ffc326bff7f0d579ed42fc7#9867b55a032a355b2ffc326bff7f0d579ed42fc7"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f778fe4183cecaec41361e65869e81e748c44a77fa3e6ba20219ca92be33a19"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -192,13 +193,17 @@ dependencies = [
  "const-hex",
  "derive_more 1.0.0",
  "getrandom",
+ "hashbrown 0.14.5",
  "hex-literal",
+ "indexmap 2.5.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -304,7 +309,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1422,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1973,6 +1978,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -2575,7 +2581,6 @@ dependencies = [
 name = "rsp-client-eth"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
  "bincode",
  "log",
  "rsp-client-executor",
@@ -2705,6 +2710,9 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -2874,7 +2882,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -2890,7 +2898,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2994,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#23c97e9e088b7eb3d5533a413c9ad416d80ba0c3"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#fca5db0b8f4a302a2501b49cb253abb0d2d97e3e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3286,7 +3294,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -3239,13 +3239,14 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v1#9b0e986d32ea128a08cebfe90767072beccdb45f"
+source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v2#8ef05d3969312eca34fa9f1f566a469022badda6"
 dependencies = [
  "bytemuck",
  "byteorder",
  "cfg-if",
  "crunchy",
  "lazy_static",
+ "num-bigint 0.4.6",
  "rand",
  "rustc-hex",
  "sp1-lib 3.2.1",

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -183,15 +183,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767e59c86900dd7c3ce3ecef04f3ace5ac9631ee150beb8b7d22f7fa3bbb2d7"
+version = "0.8.3"
+source = "git+https://github.com/xJonathanLEI/alloy-core?rev=9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9#9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "getrandom",
  "hex-literal",
  "itoa",
@@ -201,6 +200,7 @@ dependencies = [
  "rand",
  "ruint",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -756,12 +756,6 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -924,10 +918,8 @@ version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
- "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
  "syn 2.0.72",
 ]
 
@@ -946,7 +938,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -2092,7 +2084,7 @@ name = "reth-codecs-derive"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -2583,6 +2575,7 @@ dependencies = [
 name = "rsp-client-eth"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "bincode",
  "log",
  "rsp-client-executor",
@@ -2930,8 +2923,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-sha3-v0.10.8#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -3002,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "1.2.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#26fd15e457e239c379d324f156d423811421eece"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#6f67afd957bb7e3741c69651fc5d879d5edaf280"
 dependencies = [
  "anyhow",
  "bincode",

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.8.3"
-source = "git+https://github.com/xJonathanLEI/alloy-core?rev=9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9#9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9"
+source = "git+https://github.com/alloy-rs/core?rev=9867b55a032a355b2ffc326bff7f0d579ed42fc7#9867b55a032a355b2ffc326bff7f0d579ed42fc7"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -991,7 +991,7 @@ dependencies = [
  "hex-literal",
  "rfc6979",
  "signature",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
  "spki",
 ]
 
@@ -2993,8 +2993,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "1.2.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#6f67afd957bb7e3741c69651fc5d879d5edaf280"
+version = "2.0.0"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#23c97e9e088b7eb3d5533a413c9ad416d80ba0c3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3019,7 +3019,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
 ]
 
 [[package]]
@@ -3033,7 +3033,7 @@ dependencies = [
  "group",
  "pairing",
  "rand_core",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
  "subtle",
 ]
 
@@ -3099,7 +3099,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "rustc-hex",
- "sp1-lib 1.2.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
+ "sp1-lib 2.0.0",
 ]
 
 [[package]]

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -28,5 +28,5 @@ tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "pa
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
 
-# Using the fork until https://github.com/alloy-rs/core/pull/737 is merged and released
-alloy-primitives = { git = "https://github.com/xJonathanLEI/alloy-core", rev = "9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9" }
+# Using Git until https://github.com/alloy-rs/core/pull/737 is released
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "9867b55a032a355b2ffc326bff7f0d579ed42fc7" }

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -17,9 +17,16 @@ sp1-zkvm = "1.2.0"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
+# For enabling the `sha3-keccak` feature
+alloy-primitives = { version = "0.8.3", features = ["sha3-keccak"] }
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
+
+# Using the fork until https://github.com/alloy-rs/core/pull/737 is merged and released
+alloy-primitives = { git = "https://github.com/xJonathanLEI/alloy-core", rev = "9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9" }

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -17,9 +17,6 @@ sp1-zkvm = "1.2.0"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
-# For enabling the `sha3-keccak` feature
-alloy-primitives = { version = "0.8.3", features = ["sha3-keccak"] }
-
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }
@@ -27,6 +24,3 @@ ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecd
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
-
-# Using Git until https://github.com/alloy-rs/core/pull/737 is released
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "9867b55a032a355b2ffc326bff7f0d579ed42fc7" }

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -3239,13 +3239,14 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v1#9b0e986d32ea128a08cebfe90767072beccdb45f"
+source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v2#8ef05d3969312eca34fa9f1f566a469022badda6"
 dependencies = [
  "bytemuck",
  "byteorder",
  "cfg-if",
  "crunchy",
  "lazy_static",
+ "num-bigint 0.4.6",
  "rand",
  "rustc-hex",
  "sp1-lib 3.2.1",

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -183,15 +183,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767e59c86900dd7c3ce3ecef04f3ace5ac9631ee150beb8b7d22f7fa3bbb2d7"
+version = "0.8.3"
+source = "git+https://github.com/xJonathanLEI/alloy-core?rev=9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9#9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "getrandom",
  "hex-literal",
  "itoa",
@@ -201,6 +200,7 @@ dependencies = [
  "rand",
  "ruint",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -756,12 +756,6 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -924,10 +918,8 @@ version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
- "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
  "syn 2.0.72",
 ]
 
@@ -946,7 +938,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -2092,7 +2084,7 @@ name = "reth-codecs-derive"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -2615,6 +2607,7 @@ dependencies = [
 name = "rsp-client-linea"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "bincode",
  "log",
  "rsp-client-executor",
@@ -2930,8 +2923,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-sha3-v0.10.8#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -3002,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "1.2.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#26fd15e457e239c379d324f156d423811421eece"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#6f67afd957bb7e3741c69651fc5d879d5edaf280"
 dependencies = [
  "anyhow",
  "bincode",

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -183,8 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
-source = "git+https://github.com/alloy-rs/core?rev=9867b55a032a355b2ffc326bff7f0d579ed42fc7#9867b55a032a355b2ffc326bff7f0d579ed42fc7"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f778fe4183cecaec41361e65869e81e748c44a77fa3e6ba20219ca92be33a19"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -192,13 +193,17 @@ dependencies = [
  "const-hex",
  "derive_more 1.0.0",
  "getrandom",
+ "hashbrown 0.14.5",
  "hex-literal",
+ "indexmap 2.5.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -304,7 +309,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1422,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1973,6 +1978,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -2607,7 +2613,6 @@ dependencies = [
 name = "rsp-client-linea"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
  "bincode",
  "log",
  "rsp-client-executor",
@@ -2705,6 +2710,9 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -2874,7 +2882,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -2890,7 +2898,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2994,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#23c97e9e088b7eb3d5533a413c9ad416d80ba0c3"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#fca5db0b8f4a302a2501b49cb253abb0d2d97e3e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3286,7 +3294,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.8.3"
-source = "git+https://github.com/xJonathanLEI/alloy-core?rev=9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9#9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9"
+source = "git+https://github.com/alloy-rs/core?rev=9867b55a032a355b2ffc326bff7f0d579ed42fc7#9867b55a032a355b2ffc326bff7f0d579ed42fc7"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -991,7 +991,7 @@ dependencies = [
  "hex-literal",
  "rfc6979",
  "signature",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
  "spki",
 ]
 
@@ -2993,8 +2993,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "1.2.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#6f67afd957bb7e3741c69651fc5d879d5edaf280"
+version = "2.0.0"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#23c97e9e088b7eb3d5533a413c9ad416d80ba0c3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3019,7 +3019,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
 ]
 
 [[package]]
@@ -3033,7 +3033,7 @@ dependencies = [
  "group",
  "pairing",
  "rand_core",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
  "subtle",
 ]
 
@@ -3099,7 +3099,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "rustc-hex",
- "sp1-lib 1.2.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
+ "sp1-lib 2.0.0",
 ]
 
 [[package]]

--- a/bin/client-linea/Cargo.toml
+++ b/bin/client-linea/Cargo.toml
@@ -28,5 +28,5 @@ tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "pa
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
 
-# Using the fork until https://github.com/alloy-rs/core/pull/737 is merged and released
-alloy-primitives = { git = "https://github.com/xJonathanLEI/alloy-core", rev = "9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9" }
+# Using Git until https://github.com/alloy-rs/core/pull/737 is released
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "9867b55a032a355b2ffc326bff7f0d579ed42fc7" }

--- a/bin/client-linea/Cargo.toml
+++ b/bin/client-linea/Cargo.toml
@@ -17,9 +17,16 @@ sp1-zkvm = "1.2.0"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
+# For enabling the `sha3-keccak` feature
+alloy-primitives = { version = "0.8.3", features = ["sha3-keccak"] }
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
+
+# Using the fork until https://github.com/alloy-rs/core/pull/737 is merged and released
+alloy-primitives = { git = "https://github.com/xJonathanLEI/alloy-core", rev = "9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9" }

--- a/bin/client-linea/Cargo.toml
+++ b/bin/client-linea/Cargo.toml
@@ -17,9 +17,6 @@ sp1-zkvm = "1.2.0"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
-# For enabling the `sha3-keccak` feature
-alloy-primitives = { version = "0.8.3", features = ["sha3-keccak"] }
-
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }
@@ -27,6 +24,3 @@ ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecd
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
-
-# Using Git until https://github.com/alloy-rs/core/pull/737 is released
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "9867b55a032a355b2ffc326bff7f0d579ed42fc7" }

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -949,7 +949,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.9#475daa8834035cc170a567e7656329ab8de8cc44"
+source = "git+https://github.com/sp1-patches/signatures?tag=ecdsa-v0.16.9-patch-v1#475daa8834035cc170a567e7656329ab8de8cc44"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.9#475daa8834035cc170a567e7656329ab8de8cc44"
+source = "git+https://github.com/sp1-patches/signatures?tag=ecdsa-v0.16.9-patch-v1#475daa8834035cc170a567e7656329ab8de8cc44"
 dependencies = [
  "hmac",
  "subtle",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-v0.10.8#1f224388fdede7cef649bce0d63876d1a9e3f515"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.10.8-patch-v1#1f224388fdede7cef649bce0d63876d1a9e3f515"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-sha3-v0.10.8#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha3-v0.10.8-patch-v1#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?branch=patch-v0.6.0#8ef05d3969312eca34fa9f1f566a469022badda6"
+source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v2#8ef05d3969312eca34fa9f1f566a469022badda6"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -3405,9 +3405,9 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?branch=patch-v2.0.2#bf0b28f63510a90c7b6c21ac6ff461c93ecd2331"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "cfg-if",
  "crunchy",
 ]
 

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -183,15 +183,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767e59c86900dd7c3ce3ecef04f3ace5ac9631ee150beb8b7d22f7fa3bbb2d7"
+version = "0.8.3"
+source = "git+https://github.com/xJonathanLEI/alloy-core?rev=9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9#9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "getrandom",
  "hex-literal",
  "itoa",
@@ -201,6 +200,7 @@ dependencies = [
  "rand",
  "ruint",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -756,12 +756,6 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -924,10 +918,8 @@ version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
- "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
  "syn 2.0.72",
 ]
 
@@ -946,7 +938,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -2092,7 +2084,7 @@ name = "reth-codecs-derive"
 version = "1.0.6"
 source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374182a43a3602aaa953d37aa9217b"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -2615,6 +2607,7 @@ dependencies = [
 name = "rsp-client-op"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "bincode",
  "log",
  "rsp-client-executor",
@@ -2930,8 +2923,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-sha3-v0.10.8#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -3002,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "1.2.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#26fd15e457e239c379d324f156d423811421eece"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#6f67afd957bb7e3741c69651fc5d879d5edaf280"
 dependencies = [
  "anyhow",
  "bincode",

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.8.3"
-source = "git+https://github.com/xJonathanLEI/alloy-core?rev=9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9#9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9"
+source = "git+https://github.com/alloy-rs/core?rev=9867b55a032a355b2ffc326bff7f0d579ed42fc7#9867b55a032a355b2ffc326bff7f0d579ed42fc7"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -991,7 +991,7 @@ dependencies = [
  "hex-literal",
  "rfc6979",
  "signature",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
  "spki",
 ]
 
@@ -2993,8 +2993,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "1.2.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#6f67afd957bb7e3741c69651fc5d879d5edaf280"
+version = "2.0.0"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#23c97e9e088b7eb3d5533a413c9ad416d80ba0c3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3019,7 +3019,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
 ]
 
 [[package]]
@@ -3033,7 +3033,7 @@ dependencies = [
  "group",
  "pairing",
  "rand_core",
- "sp1-lib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 1.2.0",
  "subtle",
 ]
 
@@ -3099,7 +3099,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "rustc-hex",
- "sp1-lib 1.2.0 (git+https://github.com/succinctlabs/sp1?branch=dev)",
+ "sp1-lib 2.0.0",
 ]
 
 [[package]]

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -183,8 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
-source = "git+https://github.com/alloy-rs/core?rev=9867b55a032a355b2ffc326bff7f0d579ed42fc7#9867b55a032a355b2ffc326bff7f0d579ed42fc7"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f778fe4183cecaec41361e65869e81e748c44a77fa3e6ba20219ca92be33a19"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -192,13 +193,17 @@ dependencies = [
  "const-hex",
  "derive_more 1.0.0",
  "getrandom",
+ "hashbrown 0.14.5",
  "hex-literal",
+ "indexmap 2.5.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -304,7 +309,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1422,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1973,6 +1978,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -2607,7 +2613,6 @@ dependencies = [
 name = "rsp-client-op"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
  "bincode",
  "log",
  "rsp-client-executor",
@@ -2705,6 +2710,9 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -2874,7 +2882,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -2890,7 +2898,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2994,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1?branch=dev#23c97e9e088b7eb3d5533a413c9ad416d80ba0c3"
+source = "git+https://github.com/succinctlabs/sp1?branch=dev#fca5db0b8f4a302a2501b49cb253abb0d2d97e3e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3286,7 +3294,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -28,5 +28,5 @@ tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "pa
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
 
-# Using the fork until https://github.com/alloy-rs/core/pull/737 is merged and released
-alloy-primitives = { git = "https://github.com/xJonathanLEI/alloy-core", rev = "9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9" }
+# Using Git until https://github.com/alloy-rs/core/pull/737 is released
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "9867b55a032a355b2ffc326bff7f0d579ed42fc7" }

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -17,9 +17,16 @@ sp1-zkvm = "1.2.0"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
+# For enabling the `sha3-keccak` feature
+alloy-primitives = { version = "0.8.3", features = ["sha3-keccak"] }
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
+
+# Using the fork until https://github.com/alloy-rs/core/pull/737 is merged and released
+alloy-primitives = { git = "https://github.com/xJonathanLEI/alloy-core", rev = "9b4e1acf2a1cb8a54fc380577dfbdb1cb06615e9" }

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -17,9 +17,6 @@ sp1-zkvm = "1.2.0"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
-# For enabling the `sha3-keccak` feature
-alloy-primitives = { version = "0.8.3", features = ["sha3-keccak"] }
-
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-v0.10.8", package = "sha2" }
@@ -27,6 +24,3 @@ ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecd
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
 bn = { package = "substrate-bn", git = "https://github.com/sp1-patches/bn", branch = "patch-v0.6.0" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", branch = "patch-sha3-v0.10.8" }
-
-# Using Git until https://github.com/alloy-rs/core/pull/737 is released
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "9867b55a032a355b2ffc326bff7f0d579ed42fc7" }


### PR DESCRIPTION
On block `20600000` cycle count drops from `337,505,411` to `319,093,314`, or around 5.4%.