### PR TITLE
fix: revm semver violation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,30 @@ jobs:
             exit 1
           fi
 
+  deps-semver:
+    name: "Check upstream SemVer violations"
+    runs-on: ["runs-on", "runner=8cpu-linux-x64", "run-id=${{ github.run_id }}"]
+    steps:
+      - name: "Checkout sources"
+        uses: "actions/checkout@v4"
+
+      - name: "Install sp1up"
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          echo "$HOME/.sp1/bin" >> $GITHUB_PATH
+
+      - name: "Install SP1 toolchain"
+        run: |
+          sp1up
+
+      - name: "Remove lock files"
+        run: |
+          find -name Cargo.lock -type f -exec rm {} \;
+
+      - name: "Build without lock files"
+        run: |
+          cargo build --all --all-targets
+
   fmt:
     name: "Check code format"
     runs-on: ["runs-on", "runner=8cpu-linux-x64", "run-id=${{ github.run_id }}"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5399,6 +5399,8 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-trie",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,8 @@ revm-primitives = { version = "9.0.0", features = [
     "serde",
 ], default-features = false }
 revm-inspectors = "0.6"
+revm-interpreter = { version = "=10.0.1", default-features = false }
+revm-precompile = { version = "=11.0.1", default-features = false }
 
 # alloy
 alloy-primitives = "0.8.0"

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -2654,6 +2654,8 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-trie",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives",
  "serde",
  "serde_json",

--- a/bin/client-linea/Cargo.lock
+++ b/bin/client-linea/Cargo.lock
@@ -2654,6 +2654,8 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-trie",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives",
  "serde",
  "serde_json",

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -2654,6 +2654,8 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-trie",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives",
  "serde",
  "serde_json",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,6 +21,8 @@ reth-chainspec.workspace = true
 reth-optimism-chainspec.workspace = true
 
 # revm
+revm-interpreter.workspace = true
+revm-precompile.workspace = true
 revm-primitives.workspace = true
 
 # alloy


### PR DESCRIPTION
Fixes the `revm` SemVer violation issue documented in https://github.com/bluealloy/revm/issues/1812 by temporarily pinning the versions.

Also adds a CI check that make sure we can build the library in a lockless state (as would be for downstream libraries or applications) importing RSP.