### PR TITLE
perf(client, host): redundant state caching

### DIFF
--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -101,7 +101,6 @@ impl ClientExecutor {
     {
         // Initialize the witnessed database with verified storage proofs.
         let witness_db = input.witness_db()?;
-        let db = WrapDatabaseRef(witness_db);
 
         // Execute the block.
         let spec = V::spec();
@@ -114,7 +113,7 @@ impl ClientExecutor {
         })?;
         let executor_difficulty = input.current_block.header.difficulty;
         let executor_output =
-            profile!("execute", { V::execute(&executor_block_input, executor_difficulty, db) })?;
+            profile!("execute", { V::execute(&executor_block_input, executor_difficulty, witness_db) })?;
 
         // Validate the block post execution.
         profile!("validate block post-execution", {

--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -19,7 +19,7 @@ use reth_evm_optimism::OpExecutorProvider;
 use reth_execution_types::ExecutionOutcome;
 use reth_optimism_consensus::validate_block_post_execution as validate_block_post_execution_optimism;
 use reth_primitives::{proofs, Block, BlockWithSenders, Bloom, Header, Receipt, Receipts, Request};
-use revm::{db::WrapDatabaseRef, Database};
+use revm::Database;
 use revm_primitives::{address, U256};
 
 /// Chain ID for Ethereum Mainnet.
@@ -112,8 +112,9 @@ impl ClientExecutor {
                 .ok_or(eyre!("failed to recover senders"))
         })?;
         let executor_difficulty = input.current_block.header.difficulty;
-        let executor_output =
-            profile!("execute", { V::execute(&executor_block_input, executor_difficulty, witness_db) })?;
+        let executor_output = profile!("execute", {
+            V::execute(&executor_block_input, executor_difficulty, witness_db)
+        })?;
 
         // Validate the block post execution.
         profile!("validate block post-execution", {

--- a/crates/executor/client/src/lib.rs
+++ b/crates/executor/client/src/lib.rs
@@ -164,7 +164,7 @@ impl ClientExecutor {
         header.withdrawals_root = input
             .current_block
             .withdrawals
-            .clone()
+            .take()
             .map(|w| proofs::calculate_withdrawals_root(w.into_inner().as_slice()));
         header.logs_bloom = logs_bloom;
         header.requests_root =

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -5,7 +5,6 @@ use alloy_transport::Transport;
 use eyre::{eyre, Ok};
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{proofs, Block, Bloom, Receipts, B256};
-use revm::db::CacheDB;
 use rsp_client_executor::{
     io::ClientExecutorInput, ChainVariant, EthereumVariant, LineaVariant, OptimismVariant, Variant,
 };

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -14,14 +14,14 @@ use rsp_rpc_db::RpcDb;
 
 /// An executor that fetches data from a [Provider] to execute blocks in the [ClientExecutor].
 #[derive(Debug, Clone)]
-pub struct HostExecutor<T: Transport + Clone, P: Provider<T, AnyNetwork> + Clone> {
+pub struct HostExecutor<T: Transport + Clone, P: Provider<T, AnyNetwork>> {
     /// The provider which fetches data.
     pub provider: P,
     /// A phantom type to make the struct generic over the transport.
     pub phantom: PhantomData<T>,
 }
 
-impl<T: Transport + Clone, P: Provider<T, AnyNetwork> + Clone> HostExecutor<T, P> {
+impl<T: Transport + Clone, P: Provider<T, AnyNetwork>> HostExecutor<T, P> {
     /// Create a new [`HostExecutor`] with a specific [Provider] and [Transport].
     pub fn new(provider: P) -> Self {
         Self { provider, phantom: PhantomData }
@@ -67,7 +67,7 @@ impl<T: Transport + Clone, P: Provider<T, AnyNetwork> + Clone> HostExecutor<T, P
 
         // Setup the database for the block executor.
         tracing::info!("setting up the database for the block executor");
-        let mut rpc_db = RpcDb::new(self.provider.clone(), block_number - 1);
+        let mut rpc_db = RpcDb::new(&self.provider, block_number - 1);
 
         // Execute the block and fetch all the necessary data along the way.
         tracing::info!(

--- a/crates/executor/host/tests/integration.rs
+++ b/crates/executor/host/tests/integration.rs
@@ -38,8 +38,13 @@ where
         .try_init();
 
     // Setup the provider.
-    let rpc_url =
-        Url::parse(std::env::var(env_var_key).unwrap().as_str()).expect("invalid rpc url");
+    let rpc_url = Url::parse(
+        std::env::var(env_var_key)
+            .unwrap_or_else(|_| panic!("Env var {} to be set", env_var_key))
+            .as_str(),
+    )
+    .expect("invalid rpc url");
+
     let provider = ReqwestProvider::new_http(rpc_url);
 
     // Setup the host executor.

--- a/crates/storage/rpc-db/src/lib.rs
+++ b/crates/storage/rpc-db/src/lib.rs
@@ -16,8 +16,8 @@ use revm_primitives::HashMap;
 
 /// A database that fetches data from a [Provider] over a [Transport].
 ///
-/// This type is very similar to a CacheDb as exposed by revm, except we have some extra fields
-/// and the inner types are more conducive to the state we need to extract.
+/// This type is very similar to a CacheDb as exposed by revm
+/// in the sense that it will cache any RPC responses in memory.
 #[derive(Debug, Clone)]
 pub struct RpcDb<T, P> {
     /// The provider which fetches data.


### PR DESCRIPTION
## Background

Typically, `CacheDb` is used when reads from the underlying `ExtDB` are expensive. This cache represents the state at the beginning of the block, any state changes actually happen in a wrapper around the `DB: Database` type.

Internally CacheDB just stores queries in a memory map.

## Client
In the client, `CacheDB` will make everything more expensive because the underlying witnessdb is really cheap to read from, so `CacheDB` does a clone that is not needed for every read.

## Host
In the host, the `RpcDB` type does almost everything the `CacheDB` would do, this means. things like storage slots are saved twice in memory.

With minimal changes `RpcDB` we can replicate all the `CacheDB` behavior, and instead impl `Database` and we can pass a &mut of it to the executor. 