### PR TITLE
fix: ability to populate cache

### DIFF
--- a/bin/eth-proofs/src/cli.rs
+++ b/bin/eth-proofs/src/cli.rs
@@ -45,6 +45,7 @@ impl Args {
         let config = Config {
             chain: Chain::mainnet(),
             genesis: Genesis::Mainnet,
+            rpc_url: Some(self.http_rpc_url.clone()),
             cache_dir: None,
             custom_beneficiary: None,
             prove: !self.execute_only,

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> eyre::Result<()> {
     let report_path = args.report_path.clone();
     let config = args.as_config().await?;
     let persist_execution_report = PersistExecutionReport::new(config.chain.id(), report_path);
-    let rpc_client = args.provider.rpc_url.map(|rpc_url| {
+    let rpc_client = config.rpc_url.clone().map(|rpc_url| {
         RpcClient::builder().layer(RetryBackoffLayer::new(3, 1000, 100)).http(rpc_url)
     });
 

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -9,6 +9,7 @@ use revm_primitives::Address;
 use rsp_client_executor::custom::{CustomEthEvmConfig, CustomOpEvmConfig};
 use rsp_primitives::genesis::Genesis;
 use std::{path::PathBuf, sync::Arc};
+use url::Url;
 
 mod error;
 
@@ -49,6 +50,7 @@ pub fn create_op_block_execution_strategy_factory(
 pub struct Config {
     pub chain: Chain,
     pub genesis: Genesis,
+    pub rpc_url: Option<Url>,
     pub cache_dir: Option<PathBuf>,
     pub custom_beneficiary: Option<Address>,
     pub prove: bool,


### PR DESCRIPTION
Restore ability to use `RPC_X` env variables. This fix has the side effect of fixing the cache that wasn't populates when only `--chain-id` was provider and `RPC_X` env was set but not taken into account.