### PR TITLE
feat: properly handle errors when a request to ETH proofs fails

### DIFF
--- a/bin/eth-proofs/src/eth_proofs.rs
+++ b/bin/eth-proofs/src/eth_proofs.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use rsp_host_executor::ExecutionHooks;
 use sp1_sdk::{ExecutionReport, HashableKey, SP1VerifyingKey};
-use tracing::info;
+use tracing::{error, info};
 
 pub struct EthProofsClient {
     cluster_id: u64,
@@ -30,10 +30,13 @@ impl EthProofsClient {
             .header("Authorization", format!("Bearer {}", self.api_token))
             .json(json)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
 
         info!("Queued submission status: {}", response.status());
+
+        if !response.status().is_success() {
+            error!("Error response: {} ({})", response.status(), response.text().await?);
+        }
 
         Ok(())
     }
@@ -51,10 +54,12 @@ impl EthProofsClient {
             .header("Authorization", format!("Bearer {}", self.api_token))
             .json(json)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
 
         info!("Proving submission status: {}", response.status());
+        if !response.status().is_success() {
+            error!("Error response: {} ({})", response.status(), response.text().await?);
+        }
 
         Ok(())
     }

--- a/bin/eth-proofs/src/eth_proofs.rs
+++ b/bin/eth-proofs/src/eth_proofs.rs
@@ -30,12 +30,10 @@ impl EthProofsClient {
             .header("Authorization", format!("Bearer {}", self.api_token))
             .json(json)
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         info!("Queued submission status: {}", response.status());
-        if !response.status().is_success() {
-            info!("Error response: {}", response.text().await?);
-        }
 
         Ok(())
     }
@@ -53,12 +51,10 @@ impl EthProofsClient {
             .header("Authorization", format!("Bearer {}", self.api_token))
             .json(json)
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         info!("Proving submission status: {}", response.status());
-        if !response.status().is_success() {
-            info!("Error response: {}", response.text().await?);
-        }
 
         Ok(())
     }
@@ -93,12 +89,10 @@ impl EthProofsClient {
             .header("Authorization", format!("Bearer {}", self.api_token))
             .json(json)
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         info!("Proved submission status: {}", response.status());
-        if !response.status().is_success() {
-            info!("Error response: {}", response.text().await?);
-        }
 
         Ok(())
     }


### PR DESCRIPTION
Until now, when a request to Ethproofs failed we only added a log that is hard to retrieve and analyze.

With this PR, the error will be handled normally and trigger a PG alert.