### PR TITLE
refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/bin/continuous/src/cli.rs
+++ b/bin/continuous/src/cli.rs
@@ -5,26 +5,26 @@ use url::Url;
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
     /// The HTTP rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub http_rpc_url: Url,
 
     /// The WS rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub ws_rpc_url: Url,
 
     /// The database connection string.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub database_url: String,
 
     /// The maximum number of concurrent executions.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub max_concurrent_executions: usize,
 
     /// Retry count on failed execution.
-    #[clap(long, env, default_value_t = 3)]
+    #[arg(long, env, default_value_t = 3)]
     pub execution_retries: usize,
 
     /// PagerDuty integration key.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub pager_duty_integration_key: Option<String>,
 }

--- a/bin/eth-proofs/src/cli.rs
+++ b/bin/eth-proofs/src/cli.rs
@@ -1,5 +1,5 @@
 use alloy_chains::Chain;
-use clap::Parser;
+use clap::{Parser, Args};
 use rsp_host_executor::Config;
 use rsp_primitives::genesis::Genesis;
 use url::Url;
@@ -8,35 +8,35 @@ use url::Url;
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
     /// The HTTP rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub http_rpc_url: Url,
 
     /// The WS rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub ws_rpc_url: Url,
 
     /// Whether to generate a proof or just execute the block.
-    #[clap(long)]
+    #[arg(long)]
     pub execute_only: bool,
 
     /// The interval at which to execute blocks.
-    #[clap(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 100)]
     pub block_interval: u64,
 
     /// ETH proofs endpoint.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub eth_proofs_endpoint: String,
 
     /// ETH proofs API token.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub eth_proofs_api_token: String,
 
     /// Optional ETH proofs cluster ID.
-    #[clap(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1)]
     pub eth_proofs_cluster_id: u64,
 
     /// PagerDuty integration key.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub pager_duty_integration_key: Option<String>,
 }
 

--- a/bin/host/src/cli.rs
+++ b/bin/host/src/cli.rs
@@ -3,7 +3,7 @@ use std::{fs, path::PathBuf};
 use alloy_chains::Chain;
 use alloy_primitives::Address;
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
-use clap::Parser;
+use clap::{Parser, Args};
 use rsp_host_executor::Config;
 use rsp_primitives::genesis::Genesis;
 use url::Url;
@@ -12,37 +12,37 @@ use url::Url;
 #[derive(Debug, Clone, Parser)]
 pub struct HostArgs {
     /// The block number of the block to execute.
-    #[clap(long)]
+    #[arg(long)]
     pub block_number: u64,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub provider: ProviderArgs,
 
     /// The path to the genesis json file to use for the execution.
-    #[clap(long)]
+    #[arg(long)]
     pub genesis_path: Option<PathBuf>,
 
     /// The custom beneficiary address, used with Clique consensus.
-    #[clap(long)]
+    #[arg(long)]
     pub custom_beneficiary: Option<Address>,
 
     /// Whether to generate a proof or just execute the block.
-    #[clap(long)]
+    #[arg(long)]
     pub prove: bool,
 
     /// Optional path to the directory containing cached client input. A new cache file will be
     /// created from RPC data if it doesn't already exist.
-    #[clap(long)]
+    #[arg(long)]
     pub cache_dir: Option<PathBuf>,
 
     /// The path to the CSV file containing the execution data.
-    #[clap(long, default_value = "report.csv")]
+    #[arg(long, default_value = "report.csv")]
     pub report_path: PathBuf,
 
-    #[clap(long)]
+    #[arg(long)]
     /// Whether to track the cycle count of precompiles.
     pub precompile_tracking: bool,
-    #[clap(long)]
+    #[arg(long)]
     /// Whether to track the cycle count of opcodes.
     pub opcode_tracking: bool,
 }
@@ -104,13 +104,13 @@ impl HostArgs {
 }
 
 /// The arguments for configuring the chain data provider.
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, Args)]
 pub struct ProviderArgs {
     /// The rpc url used to fetch data about the block. If not provided, will use the
     /// RPC_{chain_id} env var.
-    #[clap(long)]
+    #[arg(long)]
     pub rpc_url: Option<Url>,
     /// The chain ID. If not provided, requires the rpc_url argument to be provided.
-    #[clap(long)]
+    #[arg(long)]
     pub chain_id: Option<u64>,
 }


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #101




