### PR TITLE
fix: better wait for the latest block

### DIFF
--- a/bin/host/tests/cycle_count_diff.rs
+++ b/bin/host/tests/cycle_count_diff.rs
@@ -143,7 +143,7 @@ impl ExecutionHooks for Hook {
                     r.insert("Current PR".to_string(), current.separate_with_commas());
                     r.insert(
                         "Diff".to_string(),
-                        (initial as i64 - current as i64).separate_with_commas(),
+                        (current as i64 - initial as i64).separate_with_commas(),
                     );
                     r.insert("Diff (%)".to_string(), diff);
                     r

--- a/crates/executor/host/src/full_executor.rs
+++ b/crates/executor/host/src/full_executor.rs
@@ -209,7 +209,9 @@ where
     }
 
     pub async fn wait_for_block(&self, block_number: u64) -> eyre::Result<()> {
-        while self.provider.get_block_number().await? < block_number {
+        let block_number = block_number.into();
+
+        while self.provider.get_block_by_number(block_number).await?.is_none() {
             sleep(Duration::from_millis(100)).await;
         }
         Ok(())


### PR DESCRIPTION
Sometimes, when fetching blocks with WebSockets, an event is triggered for a new block, but it's not yet available on HTTP.

Even worst,  it may happen that the latest block given by `get_block_number()` is not available with `get_block_by_number()` right away.

This PR fixes that.

Logs for reference:

```
2025-03-26T03:54:43.813177Z  INFO fetching the current block and the previous block
2025-03-26T03:54:43.875096Z  WARN Failed to execute block 22128517: RPC didnt have expected block height 22128517, retrying...
2025-03-26T03:54:43.931807Z  INFO fetching the current block and the previous block
2025-03-26T03:54:43.990532Z  WARN Failed to execute block 22128517: RPC didnt have expected block height 22128517, retrying...
2025-03-26T03:54:44.049202Z  INFO fetching the current block and the previous block
2025-03-26T03:54:44.105738Z  WARN Failed to execute block 22128517: RPC didnt have expected block height 22128517, retrying...
2025-03-26T03:54:44.163524Z  INFO fetching the current block and the previous block
2025-03-26T03:54:44.212628Z  WARN Failed to execute block 22128517: RPC didnt have expected block height 22128517, retrying...
2025-03-26T03:54:44.212649Z ERROR Max retries reached for block: 22128517
2025-03-26T03:54:44.212662Z ERROR Error executing block 22128517: RPC didnt have expected block height 22128517
```