### PR TITLE
fix: override cached opcode tracking provided flag

### DIFF
--- a/crates/executor/host/src/full_executor.rs
+++ b/crates/executor/host/src/full_executor.rs
@@ -239,7 +239,11 @@ where
         });
 
         let client_input = match client_input_from_cache {
-            Some(client_input_from_cache) => client_input_from_cache,
+            Some(mut client_input_from_cache) => {
+                // Override opcode tracking from cache by the setting provided by the user
+                client_input_from_cache.opcode_tracking = self.config.opcode_tracking;
+                client_input_from_cache
+            }
             None => {
                 let rpc_db = RpcDb::new(self.provider.clone(), block_number - 1);
 


### PR DESCRIPTION
To benchmark opcodes, the user adds  the `--opcode-tracking`, that is later included as a field in the inputs send to the guest.

But when using cached input from a previous run when `--opcode-tracking` wasn't set, the input is not updated with the flag and opcodes aren't tracked.