### PR TITLE
Decoupled proving

### DIFF
--- a/crates/executor/host/src/full_executor.rs
+++ b/crates/executor/host/src/full_executor.rs
@@ -108,6 +108,7 @@ pub trait BlockExecutor<C: ExecutorComponents> {
     #[allow(async_fn_in_trait)]
     async fn generate_proof(
         &self,
+        proving_client: Arc<C::Prover>, // NOTE: We allow using different client for proving!
         block_number: u64,
         stdin: SP1Stdin,
         hooks: &C::Hooks,
@@ -117,7 +118,7 @@ pub trait BlockExecutor<C: ExecutorComponents> {
 
         let proving_start = Instant::now();
         hooks.on_proving_start(block_number).await?;
-        let client = self.client();
+        let client = proving_client;
         let pk = self.pk();
 
         let proof = task::spawn_blocking(move || {

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -22,7 +22,9 @@ mod executor_components;
 pub use executor_components::{EthExecutorComponents, ExecutorComponents, OpExecutorComponents};
 
 mod full_executor;
-pub use full_executor::{build_executor, BlockExecutor, EitherExecutor, FullExecutor};
+pub use full_executor::{
+    build_executor, BlockExecutor, EitherExecutor, ExecutionInfo, FullExecutor,
+};
 
 mod hooks;
 pub use hooks::ExecutionHooks;


### PR DESCRIPTION
I would like to let you know that proving should be decoupled from the block execution - I use the code from this PR as a quick workaround.