### PR TITLE
feat: allow to specify proof mode

### DIFF
--- a/bin/eth-proofs/src/cli.rs
+++ b/bin/eth-proofs/src/cli.rs
@@ -53,7 +53,7 @@ impl Args {
             rpc_url: Some(self.http_rpc_url.clone()),
             cache_dir: None,
             custom_beneficiary: None,
-            prove_mode: (!self.execute_only).then_some(SP1ProofMode::Groth16),
+            prove_mode: (!self.execute_only).then_some(SP1ProofMode::Compressed),
             opcode_tracking: false,
         };
 

--- a/bin/eth-proofs/src/cli.rs
+++ b/bin/eth-proofs/src/cli.rs
@@ -2,6 +2,7 @@ use alloy_chains::Chain;
 use clap::Parser;
 use rsp_host_executor::Config;
 use rsp_primitives::genesis::Genesis;
+use sp1_sdk::SP1ProofMode;
 use url::Url;
 
 /// The arguments for the cli.
@@ -52,7 +53,7 @@ impl Args {
             rpc_url: Some(self.http_rpc_url.clone()),
             cache_dir: None,
             custom_beneficiary: None,
-            prove: !self.execute_only,
+            prove_mode: (!self.execute_only).then_some(SP1ProofMode::Groth16),
             opcode_tracking: false,
         };
 

--- a/bin/host/src/cli.rs
+++ b/bin/host/src/cli.rs
@@ -6,6 +6,7 @@ use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
 use clap::Parser;
 use rsp_host_executor::Config;
 use rsp_primitives::genesis::Genesis;
+use sp1_sdk::SP1ProofMode;
 use url::Url;
 
 /// The arguments for the host executable.
@@ -95,7 +96,7 @@ impl HostArgs {
             rpc_url,
             cache_dir: self.cache_dir.clone(),
             custom_beneficiary: self.custom_beneficiary,
-            prove: self.prove,
+            prove_mode: self.prove.then_some(SP1ProofMode::Compressed),
             opcode_tracking: self.opcode_tracking,
         };
 

--- a/bin/host/tests/cycle_count_diff.rs
+++ b/bin/host/tests/cycle_count_diff.rs
@@ -33,7 +33,7 @@ async fn test_in_zkvm() {
         rpc_url: None,
         cache_dir: None,
         custom_beneficiary: None,
-        prove: false,
+        prove_mode: None,
         opcode_tracking: false,
     };
 

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -10,6 +10,7 @@ use reth_optimism_evm::OpEvmConfig;
 use revm_primitives::Address;
 use rsp_client_executor::custom::CustomEvmFactory;
 use rsp_primitives::genesis::Genesis;
+use sp1_sdk::SP1ProofMode;
 use std::{path::PathBuf, sync::Arc};
 use url::Url;
 
@@ -54,7 +55,7 @@ pub struct Config {
     pub rpc_url: Option<Url>,
     pub cache_dir: Option<PathBuf>,
     pub custom_beneficiary: Option<Address>,
-    pub prove: bool,
+    pub prove_mode: Option<SP1ProofMode>,
     pub opcode_tracking: bool,
 }
 
@@ -66,7 +67,7 @@ impl Config {
             rpc_url: None,
             cache_dir: None,
             custom_beneficiary: None,
-            prove: false,
+            prove_mode: None,
             opcode_tracking: false,
         }
     }


### PR DESCRIPTION
In order to be able to verify proofs in browser, we need to be able to change the proof mode to one that supports verify in WASM (Groth16 and Plonk currently)