### PR TITLE
fix: handle Pectra blocks correctly

### DIFF
--- a/crates/executor/host/src/host_executor.rs
+++ b/crates/executor/host/src/host_executor.rs
@@ -212,7 +212,7 @@ impl<C: ConfigureEvm> HostExecutor<C> {
             blob_gas_used: current_block.header().blob_gas_used(),
             excess_blob_gas: current_block.header().excess_blob_gas(),
             parent_beacon_block_root: current_block.header().parent_beacon_block_root(),
-            requests_hash: None,
+            requests_hash: current_block.header().requests_hash(),
         };
 
         // Assert the derived header is correct.


### PR DESCRIPTION
Handle header `requests_hash` correctly.

Closes #120