### PR TITLE
feat: skip client execution on Eth proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6707,8 +6707,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b45dd7a9d3703f82b1f5e8fdd6c5fb8af1e3b4037f1ffc533435717d567a56"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6720,8 +6719,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1988844b2273313bf1a3861684f7415f68c00d51139475fd3d72f2326fd6d"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6744,7 +6742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-stark",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -6759,8 +6757,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7911eeaa80da1eb55ce5bf4c9442d3f1cad85e6dae41601b3ce23d45c48a5871"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -6798,7 +6795,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-stark",
  "static_assertions",
  "strum 0.26.3",
@@ -6815,8 +6812,7 @@ dependencies = [
 [[package]]
 name = "sp1-cuda"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4bab3c90ca3408ac50cbff14d629205a5178fb3623a2e354a416d9d7560fe02"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -6832,8 +6828,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a198a00a1700ea0073a7481138abf256e3f38a15892c42721cdbec5d64d0f4e7"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6846,7 +6841,7 @@ dependencies = [
  "p3-field",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-stark",
  "typenum",
 ]
@@ -6854,8 +6849,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e3a9d2afa63fa83792c223084abf62c2cb3a60188651e9aa567e25e9fd344d"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6870,7 +6864,7 @@ dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6894,10 +6888,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-primitives"
+version = "4.2.0"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
+dependencies = [
+ "bincode",
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "p3-baby-bear",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "sp1-prover"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694e15302f83608c4be7efbf879f0f2b04c2f90129fc8fe9b625299f59e6200"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6926,7 +6938,7 @@ dependencies = [
  "sha2",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -6941,8 +6953,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d651075d5de59e212f02ae7d6f1155e5fe2af228c0cab92096d4e8359b619"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6965,7 +6976,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -6976,8 +6987,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630ab95063c1cf52668b23cdae8a216f5749604c3b063f5cdec20ef2c60d086"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6987,7 +6997,7 @@ dependencies = [
  "p3-symmetric",
  "serde",
  "sp1-core-machine",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -6998,8 +7008,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-core"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2edcf518cedb3d0947f14688089812aec56089b45bdfc5dd162ea25ec8902d7"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -7029,7 +7038,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -7041,8 +7050,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-derive"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45acfb50730a6271d8546975063df0946ffaa28d2ce0d0041e7905fb90c9c254"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7051,8 +7059,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e1bc3fc71f6eafaa1dc5fa9b309ecf55075c14a18561540937a1e2e3964670"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7077,8 +7084,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dc0553bed3674fe271a65dd9cdd3569670c619fdc3aaac7588cc6fce39e622"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -7109,7 +7115,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "sp1-prover",
  "sp1-stark",
  "strum 0.26.3",
@@ -7125,8 +7131,7 @@ dependencies = [
 [[package]]
 name = "sp1-stark"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3623ca4fe6bf08b3f4211f63cc59a115f0559913e2846ec4e65ad4a8524de3d"
+source = "git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a#42dbf08c6167641812162ed0d146dfed3ca0517a"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -7150,7 +7155,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives",
+ "sp1-primitives 4.2.0 (git+https://github.com/succinctlabs/sp1?rev=42dbf08c6167641812162ed0d146dfed3ca0517a)",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "sysinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,3 +140,9 @@ bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-4.0.0",
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
+
+# Needed for prove_with_cycles(), can be removed once SP1 v4.2.1 is out
+sp1-build = { git = "https://github.com/succinctlabs/sp1", rev = "42dbf08c6167641812162ed0d146dfed3ca0517a" }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "42dbf08c6167641812162ed0d146dfed3ca0517a" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "42dbf08c6167641812162ed0d146dfed3ca0517a" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "42dbf08c6167641812162ed0d146dfed3ca0517a"}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RSP is a minimal implementation of generating zero-knowledge proofs of EVM block execution using [Reth](https://reth.rs). Supports both Ethereum and OP Stack.
 
-[Docs](https://succinctlabs.github.io/)
+[Docs](https://succinctlabs.github.io/rsp/)
 
 ## Overview
 

--- a/bin/eth-proofs/src/cli.rs
+++ b/bin/eth-proofs/src/cli.rs
@@ -54,6 +54,7 @@ impl Args {
             cache_dir: None,
             custom_beneficiary: None,
             prove_mode: (!self.execute_only).then_some(SP1ProofMode::Compressed),
+            skip_client_execution: true,
             opcode_tracking: false,
         };
 

--- a/bin/host/src/cli.rs
+++ b/bin/host/src/cli.rs
@@ -97,6 +97,7 @@ impl HostArgs {
             cache_dir: self.cache_dir.clone(),
             custom_beneficiary: self.custom_beneficiary,
             prove_mode: self.prove.then_some(SP1ProofMode::Compressed),
+            skip_client_execution: false,
             opcode_tracking: self.opcode_tracking,
         };
 

--- a/bin/host/tests/cycle_count_diff.rs
+++ b/bin/host/tests/cycle_count_diff.rs
@@ -34,6 +34,7 @@ async fn test_in_zkvm() {
         cache_dir: None,
         custom_beneficiary: None,
         prove_mode: None,
+        skip_client_execution: false,
         opcode_tracking: false,
     };
 

--- a/crates/executor/host/src/full_executor.rs
+++ b/crates/executor/host/src/full_executor.rs
@@ -14,14 +14,14 @@ use rsp_client_executor::io::ClientExecutorInput;
 use rsp_rpc_db::RpcDb;
 use serde::de::DeserializeOwned;
 use sp1_prover::components::CpuProverComponents;
-use sp1_sdk::{
-    ExecutionReport, Prover, SP1ProofMode, SP1ProvingKey, SP1PublicValues, SP1Stdin,
-    SP1VerifyingKey,
-};
+use sp1_sdk::{ExecutionReport, Prover, SP1ProvingKey, SP1PublicValues, SP1Stdin, SP1VerifyingKey};
 use tokio::{task, time::sleep};
 use tracing::{info, info_span, warn};
 
-use crate::{Config, ExecutionHooks, ExecutorComponents, HostExecutor};
+use crate::{
+    executor_components::MaybeProveWithCycles, Config, ExecutionHooks, ExecutorComponents,
+    HostExecutor,
+};
 
 pub type EitherExecutor<C, P> = Either<FullExecutor<C, P>, CachedExecutor<C>>;
 
@@ -43,17 +43,9 @@ where
         ));
     }
 
-    if let Some(cache_dir) = config.cache_dir {
+    if let Some(cache_dir) = &config.cache_dir {
         return Ok(Either::Right(
-            CachedExecutor::try_new(
-                elf,
-                client,
-                hooks,
-                cache_dir,
-                config.chain.id(),
-                config.prove_mode,
-            )
-            .await?,
+            CachedExecutor::try_new(elf, client, hooks, cache_dir.clone(), config).await?,
         ));
     }
 
@@ -70,12 +62,13 @@ pub trait BlockExecutor<C: ExecutorComponents> {
 
     fn vk(&self) -> Arc<SP1VerifyingKey>;
 
+    fn config(&self) -> &Config;
+
     #[allow(async_fn_in_trait)]
     async fn process_client(
         &self,
         client_input: ClientExecutorInput<C::Primitives>,
         hooks: &C::Hooks,
-        prove_mode: Option<SP1ProofMode>,
     ) -> eyre::Result<()> {
         // Generate the proof.
         // Execute the block inside the zkVM.
@@ -84,21 +77,31 @@ pub trait BlockExecutor<C: ExecutorComponents> {
 
         stdin.write_vec(buffer);
 
-        // Only execute the program.
-        let (stdin, execute_result) =
-            execute_client(client_input.current_block.number, self.client(), self.pk(), stdin)
-                .await?;
-        let (mut public_values, execution_report) = execute_result?;
+        let stdin = Arc::new(stdin);
 
-        // Read the block hash.
-        let block_hash = public_values.read::<B256>();
-        info!(?block_hash, "Execution successful");
-
-        hooks
-            .on_execution_end::<C::Primitives>(&client_input.current_block, &execution_report)
+        if self.config().skip_client_execution {
+            info!("Client execution skipped");
+        } else {
+            // Only execute the program.
+            let execute_result = execute_client(
+                client_input.current_block.number,
+                self.client(),
+                self.pk(),
+                stdin.clone(),
+            )
             .await?;
+            let (mut public_values, execution_report) = execute_result?;
 
-        if let Some(prove_mode) = prove_mode {
+            // Read the block hash.
+            let block_hash = public_values.read::<B256>();
+            info!(?block_hash, "Execution successful");
+
+            hooks
+                .on_execution_end::<C::Primitives>(&client_input.current_block, &execution_report)
+                .await?;
+        }
+
+        if let Some(prove_mode) = self.config().prove_mode {
             info!("Starting proof generation");
 
             let proving_start = Instant::now();
@@ -106,8 +109,10 @@ pub trait BlockExecutor<C: ExecutorComponents> {
             let client = self.client();
             let pk = self.pk();
 
-            let proof = task::spawn_blocking(move || {
-                client.prove(pk.as_ref(), &stdin, prove_mode).map_err(|err| eyre::eyre!("{err}"))
+            let (proof, cycle_count) = task::spawn_blocking(move || {
+                client
+                    .prove_with_cycles(pk.as_ref(), &stdin, prove_mode)
+                    .map_err(|err| eyre::eyre!("{err}"))
             })
             .await
             .map_err(|err| eyre::eyre!("{err}"))??;
@@ -120,7 +125,7 @@ pub trait BlockExecutor<C: ExecutorComponents> {
                     client_input.current_block.number,
                     &proof_bytes,
                     self.vk().as_ref(),
-                    &execution_report,
+                    cycle_count,
                     proving_duration,
                 )
                 .await?;
@@ -162,6 +167,13 @@ where
         match self {
             Either::Left(ref executor) => executor.vk.clone(),
             Either::Right(ref executor) => executor.vk.clone(),
+        }
+    }
+
+    fn config(&self) -> &Config {
+        match self {
+            Either::Left(executor) => executor.config(),
+            Either::Right(executor) => executor.config(),
         }
     }
 }
@@ -283,7 +295,7 @@ where
             }
         };
 
-        self.process_client(client_input, &self.hooks, self.config.prove_mode).await?;
+        self.process_client(client_input, &self.hooks).await?;
 
         Ok(())
     }
@@ -298,6 +310,10 @@ where
 
     fn vk(&self) -> Arc<SP1VerifyingKey> {
         self.vk.clone()
+    }
+
+    fn config(&self) -> &Config {
+        &self.config
     }
 }
 
@@ -316,12 +332,11 @@ where
     C: ExecutorComponents,
 {
     cache_dir: PathBuf,
-    chain_id: u64,
     client: Arc<C::Prover>,
     pk: Arc<SP1ProvingKey>,
     vk: Arc<SP1VerifyingKey>,
     hooks: C::Hooks,
-    prove_mode: Option<SP1ProofMode>,
+    config: Config,
 }
 
 impl<C> CachedExecutor<C>
@@ -333,8 +348,7 @@ where
         client: Arc<C::Prover>,
         hooks: C::Hooks,
         cache_dir: PathBuf,
-        chain_id: u64,
-        prove_mode: Option<SP1ProofMode>,
+        config: Config,
     ) -> eyre::Result<Self> {
         let cloned_client = client.clone();
 
@@ -345,15 +359,7 @@ where
         })
         .await?;
 
-        Ok(Self {
-            cache_dir,
-            chain_id,
-            client,
-            pk: Arc::new(pk),
-            vk: Arc::new(vk),
-            hooks,
-            prove_mode,
-        })
+        Ok(Self { cache_dir, client, pk: Arc::new(pk), vk: Arc::new(vk), hooks, config })
     }
 }
 
@@ -364,12 +370,12 @@ where
     async fn execute(&self, block_number: u64) -> eyre::Result<()> {
         let client_input = try_load_input_from_cache::<C::Primitives>(
             &self.cache_dir,
-            self.chain_id,
+            self.config.chain.id(),
             block_number,
         )?
         .ok_or(eyre::eyre!("No cached input found"))?;
 
-        self.process_client(client_input, &self.hooks, self.prove_mode).await
+        self.process_client(client_input, &self.hooks).await
     }
 
     fn client(&self) -> Arc<C::Prover> {
@@ -382,6 +388,10 @@ where
 
     fn vk(&self) -> Arc<SP1VerifyingKey> {
         self.vk.clone()
+    }
+
+    fn config(&self) -> &Config {
+        &self.config
     }
 }
 
@@ -399,12 +409,12 @@ async fn execute_client<P: Prover<CpuProverComponents> + 'static>(
     number: u64,
     client: Arc<P>,
     pk: Arc<SP1ProvingKey>,
-    stdin: SP1Stdin,
-) -> eyre::Result<(SP1Stdin, eyre::Result<(SP1PublicValues, ExecutionReport)>)> {
+    stdin: Arc<SP1Stdin>,
+) -> eyre::Result<eyre::Result<(SP1PublicValues, ExecutionReport)>> {
     task::spawn_blocking(move || {
         info_span!("execute_client", number).in_scope(|| {
             let result = client.execute(&pk.elf, &stdin);
-            (stdin, result.map_err(|err| eyre::eyre!("{err}")))
+            result.map_err(|err| eyre::eyre!("{err}"))
         })
     })
     .await

--- a/crates/executor/host/src/hooks.rs
+++ b/crates/executor/host/src/hooks.rs
@@ -29,7 +29,7 @@ pub trait ExecutionHooks: Send {
         _block_number: u64,
         _proof_bytes: &[u8],
         _vk: &SP1VerifyingKey,
-        _execution_report: &ExecutionReport,
+        _cycle_count: Option<u64>,
         _proving_duration: Duration,
     ) -> impl Future<Output = eyre::Result<()>> {
         async { Ok(()) }

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -56,6 +56,7 @@ pub struct Config {
     pub cache_dir: Option<PathBuf>,
     pub custom_beneficiary: Option<Address>,
     pub prove_mode: Option<SP1ProofMode>,
+    pub skip_client_execution: bool,
     pub opcode_tracking: bool,
 }
 
@@ -68,6 +69,7 @@ impl Config {
             cache_dir: None,
             custom_beneficiary: None,
             prove_mode: None,
+            skip_client_execution: false,
             opcode_tracking: false,
         }
     }


### PR DESCRIPTION
For Eth proofs, we need to provide the cycle count. To have this information, until recently, we needed to execute the program in the zkVM. Now, with `prove_with_cycles()` added to `CudaProver`, we have access to the cycle count when proving.

This saves ~10-30s on total proving time for Eth proof.