### PR TITLE
Fix various issues including `#[clap]` transformation, broken links, and spelling errors

### DIFF
--- a/bin/client/src/main.rs
+++ b/bin/client/src/main.rs
@@ -2,7 +2,7 @@
 sp1_zkvm::entrypoint!(main);
 
 use rsp_client_executor::{
-    executor::{EthClientExecutor, DESERIALZE_INPUTS},
+    executor::{EthClientExecutor, DESERIALIZE_INPUTS},
     io::{CommittedHeader, EthClientExecutorInput},
 };
 use std::sync::Arc;

--- a/bin/client/src/main.rs
+++ b/bin/client/src/main.rs
@@ -9,10 +9,10 @@ use std::sync::Arc;
 
 pub fn main() {
     // Read the input.
-    println!("cycle-tracker-report-start: {}", DESERIALZE_INPUTS);
+    println!("cycle-tracker-report-start: {}", DESERIALIZE_INPUTS);
     let input = sp1_zkvm::io::read_vec();
     let input = bincode::deserialize::<EthClientExecutorInput>(&input).unwrap();
-    println!("cycle-tracker-report-end: {}", DESERIALZE_INPUTS);
+    println!("cycle-tracker-report-end: {}", DESERIALIZE_INPUTS);
 
     // Execute the block.
     let executor = EthClientExecutor::eth(

--- a/bin/continuous/src/cli.rs
+++ b/bin/continuous/src/cli.rs
@@ -5,26 +5,26 @@ use url::Url;
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
     /// The HTTP rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub http_rpc_url: Url,
 
     /// The WS rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub ws_rpc_url: Url,
 
     /// The database connection string.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub database_url: String,
 
     /// The maximum number of concurrent executions.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub max_concurrent_executions: usize,
 
     /// Retry count on failed execution.
-    #[clap(long, env, default_value_t = 3)]
+    #[arg(long, env, default_value_t = 3)]
     pub execution_retries: usize,
 
     /// PagerDuty integration key.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub pager_duty_integration_key: Option<String>,
 }

--- a/bin/continuous/src/main.rs
+++ b/bin/continuous/src/main.rs
@@ -131,7 +131,7 @@ where
 {
     let mut retry_count = 0;
 
-    // Wait for the block to be avaliable in the HTTP provider
+    // Wait for the block to be available in the HTTP provider
     executor.wait_for_block(number).await?;
 
     loop {

--- a/bin/eth-proofs/src/cli.rs
+++ b/bin/eth-proofs/src/cli.rs
@@ -9,39 +9,39 @@ use url::Url;
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
     /// The HTTP rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub http_rpc_url: Url,
 
     /// The WS rpc url used to fetch data about the block.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub ws_rpc_url: Url,
 
     /// Whether to generate a proof or just execute the block.
-    #[clap(long)]
+    #[arg(long)]
     pub execute_only: bool,
 
     /// The interval at which to execute blocks.
-    #[clap(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 100)]
     pub block_interval: u64,
 
     /// ETH proofs endpoint.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub eth_proofs_endpoint: String,
 
     /// ETH proofs API token.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub eth_proofs_api_token: String,
 
     /// Optional ETH proofs cluster ID.
-    #[clap(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1)]
     pub eth_proofs_cluster_id: u64,
 
     /// PagerDuty integration key.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub pager_duty_integration_key: Option<String>,
 
     /// Moongate server endpoint.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub moongate_endpoint: Option<String>,
 }
 

--- a/bin/host/src/cli.rs
+++ b/bin/host/src/cli.rs
@@ -13,37 +13,37 @@ use url::Url;
 #[derive(Debug, Clone, Parser)]
 pub struct HostArgs {
     /// The block number of the block to execute.
-    #[clap(long)]
+    #[arg(long)]
     pub block_number: u64,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub provider: ProviderArgs,
 
     /// The path to the genesis json file to use for the execution.
-    #[clap(long)]
+    #[arg(long)]
     pub genesis_path: Option<PathBuf>,
 
     /// The custom beneficiary address, used with Clique consensus.
-    #[clap(long)]
+    #[arg(long)]
     pub custom_beneficiary: Option<Address>,
 
     /// Whether to generate a proof or just execute the block.
-    #[clap(long)]
+    #[arg(long)]
     pub prove: bool,
 
     /// Optional path to the directory containing cached client input. A new cache file will be
     /// created from RPC data if it doesn't already exist.
-    #[clap(long)]
+    #[arg(long)]
     pub cache_dir: Option<PathBuf>,
 
     /// The path to the CSV file containing the execution data.
-    #[clap(long, default_value = "report.csv")]
+    #[arg(long, default_value = "report.csv")]
     pub report_path: PathBuf,
 
-    #[clap(long)]
+    #[arg(long)]
     /// Whether to track the cycle count of precompiles.
     pub precompile_tracking: bool,
-    #[clap(long)]
+    #[arg(long)]
     /// Whether to track the cycle count of opcodes.
     pub opcode_tracking: bool,
 }
@@ -110,9 +110,9 @@ impl HostArgs {
 pub struct ProviderArgs {
     /// The rpc url used to fetch data about the block. If not provided, will use the
     /// RPC_{chain_id} env var.
-    #[clap(long)]
+    #[arg(long)]
     pub rpc_url: Option<Url>,
     /// The chain ID. If not provided, requires the rpc_url argument to be provided.
-    #[clap(long)]
+    #[arg(long)]
     pub chain_id: Option<u64>,
 }

--- a/bin/host/src/execute.rs
+++ b/bin/host/src/execute.rs
@@ -3,7 +3,7 @@ use csv::{Writer, WriterBuilder};
 use reth_primitives_traits::{BlockBody, NodePrimitives};
 use revm_bytecode::opcode::OPCODE_INFO;
 use rsp_client_executor::executor::{
-    ACCRUE_LOG_BLOOM, BLOCK_EXECUTION, COMPUTE_STATE_ROOT, DESERIALZE_INPUTS, INIT_WITNESS_DB,
+    ACCRUE_LOG_BLOOM, BLOCK_EXECUTION, COMPUTE_STATE_ROOT, DESERIALIZE_INPUTS, INIT_WITNESS_DB,
     RECOVER_SENDERS, VALIDATE_EXECUTION,
 };
 use rsp_host_executor::ExecutionHooks;
@@ -138,7 +138,7 @@ impl PersistExecutionReport {
         } else {
             record.push(execution_report.total_instruction_count().to_string());
             record.push(
-                execution_report.cycle_tracker.get(DESERIALZE_INPUTS).unwrap_or(&0).to_string(),
+                execution_report.cycle_tracker.get(DESERIALIZE_INPUTS).unwrap_or(&0).to_string(),
             );
             record.push(
                 execution_report.cycle_tracker.get(INIT_WITNESS_DB).unwrap_or(&0).to_string(),

--- a/bin/host/tests/cycle_count_diff.rs
+++ b/bin/host/tests/cycle_count_diff.rs
@@ -7,7 +7,7 @@ use alloy_provider::RootProvider;
 use madato::{mk_table, types::TableRow};
 use reth_primitives_traits::NodePrimitives;
 use rsp_client_executor::executor::{
-    ACCRUE_LOG_BLOOM, BLOCK_EXECUTION, COMPUTE_STATE_ROOT, DESERIALZE_INPUTS, INIT_WITNESS_DB,
+    ACCRUE_LOG_BLOOM, BLOCK_EXECUTION, COMPUTE_STATE_ROOT, DESERIALIZE_INPUTS, INIT_WITNESS_DB,
     RECOVER_SENDERS, VALIDATE_EXECUTION, VALIDATE_HEADER,
 };
 use rsp_host_executor::{
@@ -87,7 +87,7 @@ impl ExecutionHooks for Hook {
                     total_cycle_count: execution_report.total_instruction_count(),
                     deserialize_inputs: execution_report
                         .cycle_tracker
-                        .get(DESERIALZE_INPUTS)
+                        .get(DESERIALIZE_INPUTS)
                         .copied()
                         .unwrap_or(0),
                     initialize_witness_db_cycles_count: execution_report
@@ -166,7 +166,7 @@ impl ExecutionHooks for Hook {
                             "Inputs deserialization",
                             execution_report
                                 .cycle_tracker
-                                .get(DESERIALZE_INPUTS)
+                                .get(DESERIALIZE_INPUTS)
                                 .copied()
                                 .unwrap_or_default(),
                             current_dev_stats.deserialize_inputs,

--- a/book/docs/02-Getting-started.md
+++ b/book/docs/02-Getting-started.md
@@ -31,4 +31,4 @@ When running RSP, you should see logs similar to:
 ...
 ```
 
-The host CLI executes the block while fetching additional data necessary for offline execution. The same execution and verification logic is then run inside the zkVM. No actual proof is generated from this command, but it will print out a detailed execution report. If you want to generate proofs, see [Generating proofs](./Generating-proofs).
+The host CLI executes the block while fetching additional data necessary for offline execution. The same execution and verification logic is then run inside the zkVM. No actual proof is generated from this command, but it will print out a detailed execution report. If you want to generate proofs, see [Generating proofs](./04-Generating-proofs.md).

--- a/book/docs/03-RPC-configuration.md
+++ b/book/docs/03-RPC-configuration.md
@@ -11,7 +11,7 @@ We supports the following chains:
 * Linea (59144)
 * Sepolia (11155111)
 
-RSP can be run on other custom chains. See the [Custom chains](./Advanced/03-Custom-chains.md) page for more details.
+RSP can be run on other custom chains. See the [Custom chains](./05-Advanced/03-Custom-chains.md) page for more details.
 
 ## RPC Node Requirements
 

--- a/book/docs/03-RPC-configuration.md
+++ b/book/docs/03-RPC-configuration.md
@@ -11,7 +11,7 @@ We supports the following chains:
 * Linea (59144)
 * Sepolia (11155111)
 
-RSP can be run on other custom chains. See the [Custom chains](./Advanced/Custom-chains) page for more details.
+RSP can be run on other custom chains. See the [Custom chains](./Advanced/03-Custom-chains.md) page for more details.
 
 ## RPC Node Requirements
 

--- a/book/docs/05-Advanced/04-Running-tests.md
+++ b/book/docs/05-Advanced/04-Running-tests.md
@@ -9,7 +9,7 @@ export RPC_59144="YOUR_LINEA_MAINNET_RPC_URL"
 export RPC_11155111="YOUR_SEPOLIA_RPC_URL"
 ```
 
-Note that these JSON-RPC nodes must fulfill the [RPC node requirement](../RPC-configuration#rpc-node-requirements).
+Note that these JSON-RPC nodes must fulfill the [RPC node requirement](../03-RPC-configuration.md#rpc-node-requirements).
 
 Then execute:
 

--- a/book/docusaurus.config.ts
+++ b/book/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'RSP Book',
-  tagline: 'Powered by Succinct SP{1',
+  tagline: 'Powered by Succinct SP1',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/crates/executor/client/src/custom.rs
+++ b/crates/executor/client/src/custom.rs
@@ -1,4 +1,4 @@
-//! A cunstom EVM configuration for annotated precompiles.
+//! A custom EVM configuration for annotated precompiles.
 //!
 //! Originally from: https://github.com/paradigmxyz/alphanet/blob/main/crates/node/src/evm.rs.
 //!

--- a/crates/executor/client/src/error.rs
+++ b/crates/executor/client/src/error.rs
@@ -21,7 +21,7 @@ pub enum ClientError {
     InvalidHeaderBlockNumber(u64, u64),
     #[error("Invalid parent header found for block \n expected: {}, found: {}", .0, .1)]
     InvalidHeaderParentHash(FixedBytes<32>, FixedBytes<32>),
-    #[error("Failed to validate post exectution state {}", 0)]
+    #[error("Failed to validate post execution state {}", 0)]
     PostExecutionError(#[from] ConsensusError),
     #[error("Block Execution Failed: {}", .0)]
     BlockExecutionError(#[from] BlockExecutionError),

--- a/crates/executor/client/src/executor.rs
+++ b/crates/executor/client/src/executor.rs
@@ -25,7 +25,7 @@ use crate::{
     BlockValidator,
 };
 
-pub const DESERIALZE_INPUTS: &str = "deserialize inputs";
+pub const DESERIALIZE_INPUTS: &str = "deserialize inputs";
 pub const INIT_WITNESS_DB: &str = "initialize witness db";
 pub const RECOVER_SENDERS: &str = "recover senders";
 pub const BLOCK_EXECUTION: &str = "block execution";

--- a/crates/executor/host/src/alerting.rs
+++ b/crates/executor/host/src/alerting.rs
@@ -3,7 +3,7 @@
 use serde::Serialize;
 use tracing::error;
 
-const PAGER_DUTY_ENDPOINT: &str = "https://events.pagerduty.com/v2";
+const PAGER_DUTY_ENDPOINT: &str = "https://www.pagerduty.com/events/";
 
 #[derive(Debug)]
 pub struct AlertingClient {

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -13,7 +13,7 @@ pub enum Genesis {
     Custom(String),
 }
 
-/// Returns the [alloy_genesis::Genesis] fron a json string.
+/// Returns the [alloy_genesis::Genesis] from a json string.
 pub fn genesis_from_json(json: &str) -> eyre::Result<alloy_genesis::Genesis> {
     let genesis = serde_json::from_str::<alloy_genesis::Genesis>(json)?;
 


### PR DESCRIPTION
This PR addresses multiple issues across the codebase:

- Transformed `#[clap]` to `#[arg]` or `#[command]` where applicable to match the latest standards.
- Fixed broken documentation links:
  - In `book/docs/05-Advanced/04-Running-tests.md`, replaced `RPC-configuration#rpc-node-requirements` with `03-RPC-configuration.md`.
  - Updated `./Advanced/Custom-chains` to the correct path `./Advanced/03-Custom-chains.md` in `book/docs/03-RPC-configuration.md`.
  - Fixed the incorrect "Generating-proofs.md" link in `book/docs/02-Getting-started.md`.
  - Corrected the outdated PagerDuty link to `https://www.pagerduty.com/events/` in `crates/executor/host/src/alerting.rs`.
- Corrected the spelling error `DESERIALZE_INPUTS` to `DESERIALIZE_INPUTS` in various files.
- Fixed various spelling errors, including:
  - `fron` -> `from` in `crates/primitives/src/genesis.rs`.
  - `exectution` -> `execution` in `crates/executor/client/src/error.rs`.
  - `cunstom` -> `custom` in `crates/executor/client/src/custom.rs`.
  - `SP{1` -> `SP1` in `book/docusaurus.config.ts`.
- Other small improvements like fixing a typo in the text "Wait for the block to be avaliable" in `bin/continuous/src/main.rs`.

The changes made aim to clean up the code, fix broken links, and improve documentation consistency.

Additionally, I tested the changes with `cargo clippy` and `cargo build`:

Error: 
![Pasted Graphic 15](https://github.com/user-attachments/assets/0c056732-d7cd-4d3c-a498-fea129cdfacd)

Fix: 
![Finished 'dev' profile (unoptimized + debuginfol target(s) in 5 36s](https://github.com/user-attachments/assets/c406de66-d6f7-4c01-8b47-db31eb7166ec)

`cargo clippy --workspace --all-targets --all-features -- -D warnings `
![Pasted Graphic 17](https://github.com/user-attachments/assets/7a892cef-2d7d-4950-a0e7-623587ab28e8)

`cargo build`
![Pasted Graphic 18](https://github.com/user-attachments/assets/07f6ff6b-0dba-4c78-90a6-24ab668181ed)

*Note*: Due to issues I faced on my PC, I had to make the changes through the GitHub web interface, so you will see 18 commit messages. If needed, I can squash them at a later time, or if not required, it works fine for me as well.
