### PR TITLE
feat: creates MPT from account proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6065,6 +6065,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "hex-literal",
  "reth-trie",
  "rlp",

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -3764,6 +3764,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "reth-trie",
  "rlp",
  "serde",

--- a/bin/client/Cargo.lock
+++ b/bin/client/Cargo.lock
@@ -3554,6 +3554,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "reth-trie",
  "rlp",
  "serde",

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -21,6 +21,7 @@ reth-trie.workspace = true
 # alloy
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 
 /// Module containing MPT code adapted from `zeth`.
 mod mpt;
-pub use mpt::Error;
-use mpt::{proofs_to_tries, transition_proofs_to_tries, MptNode};
+use mpt::{proofs_to_tries, transition_proofs_to_tries};
+pub use mpt::{Error, MptNode};
 
 /// Ethereum state trie and account storage tries.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/mpt/src/mpt.rs
+++ b/crates/mpt/src/mpt.rs
@@ -20,7 +20,7 @@
 #![allow(dead_code)]
 
 use alloc::boxed::Box;
-use alloy_primitives::{b256, map::HashMap, B256};
+use alloy_primitives::{b256, map::HashMap, Bytes, B256};
 use alloy_rlp::Encodable;
 use core::{
     cell::RefCell,
@@ -287,6 +287,12 @@ impl Decodable for MptNode {
 /// and retrieving values, as well as utility methods for encoding, decoding, and
 /// debugging.
 impl MptNode {
+    /// Creates a Merkle Patricia trie from an EIP-1186 proof.
+    pub fn try_from_account_proof(account_proof: &[Bytes]) -> Result<Self, FromProofError> {
+        let nodes = parse_proof(account_proof)?;
+        mpt_from_proof(&nodes)
+    }
+
     /// Clears the trie, replacing its data with an empty node, [MptNodeData::Null].
     ///
     /// This method effectively removes all key-value pairs from the trie.

--- a/crates/mpt/src/mpt.rs
+++ b/crates/mpt/src/mpt.rs
@@ -20,7 +20,7 @@
 #![allow(dead_code)]
 
 use alloc::boxed::Box;
-use alloy_primitives::{b256, map::HashMap, Bytes, B256};
+use alloy_primitives::{b256, map::HashMap, B256};
 use alloy_rlp::Encodable;
 use core::{
     cell::RefCell,
@@ -288,9 +288,7 @@ impl Decodable for MptNode {
 /// debugging.
 impl MptNode {
     /// Creates a Merkle Patricia trie from an EIP-1186 proof.
-    pub fn try_from_account_proof(
-        account_proof: &[impl AsRef<[u8]>],
-    ) -> Result<Self, FromProofError> {
+    pub fn from_account_proof(account_proof: &[impl AsRef<[u8]>]) -> Result<Self, FromProofError> {
         let nodes = parse_proof(account_proof)?;
         mpt_from_proof(&nodes)
     }

--- a/crates/mpt/src/mpt.rs
+++ b/crates/mpt/src/mpt.rs
@@ -288,7 +288,9 @@ impl Decodable for MptNode {
 /// debugging.
 impl MptNode {
     /// Creates a Merkle Patricia trie from an EIP-1186 proof.
-    pub fn try_from_account_proof(account_proof: &[Bytes]) -> Result<Self, FromProofError> {
+    pub fn try_from_account_proof(
+        account_proof: &[impl AsRef<[u8]>],
+    ) -> Result<Self, FromProofError> {
         let nodes = parse_proof(account_proof)?;
         mpt_from_proof(&nodes)
     }


### PR DESCRIPTION
Allow to create a `MptNode` from an EIP-1186 proof.