### PR TITLE
fix: use OpChainSpec::from_genesis

### DIFF
--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -140,12 +140,11 @@ impl TryFrom<&Genesis> for reth_optimism_chainspec::OpChainSpec {
                 Ok(op_mainnet)
             }
             Genesis::Custom(config) => {
-                let custom = reth_optimism_chainspec::OpChainSpec {
-                    inner: ChainSpec::from_genesis(alloy_genesis::Genesis {
+                let custom =
+                    reth_optimism_chainspec::OpChainSpec::from_genesis(alloy_genesis::Genesis {
                         config: config.clone(),
                         ..Default::default()
-                    }),
-                };
+                    });
 
                 Ok(custom)
             }


### PR DESCRIPTION
In order to take OP stack hardforks into account.