### PR TITLE
fix: allow to serialize ChainConfig with bincode

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: "Set up test fixture"
         run: |
-          git clone https://github.com/succinctlabs/rsp-tests --branch 2025-02-13 --depth 1 ../rsp-tests
+          git clone https://github.com/succinctlabs/rsp-tests --branch 2025-06-16 --depth 1 ../rsp-tests
           cd ../rsp-tests/
           docker compose up -d
 
@@ -132,6 +132,7 @@ jobs:
           echo "RPC_10=http://localhost:9545/main/evm/10" >> $GITHUB_ENV
           echo "RPC_59144=http://localhost:9545/main/evm/59144" >> $GITHUB_ENV
           echo "RPC_11155111=http://localhost:9545/main/evm/11155111" >> $GITHUB_ENV
+          echo "RPC_11155420=http://localhost:9545/main/evm/11155420" >> $GITHUB_ENV
 
       - name: "Run tests"
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6081,8 +6081,12 @@ dependencies = [
 name = "rsp-primitives"
 version = "0.1.0"
 dependencies = [
+ "alloy-eips",
  "alloy-genesis",
+ "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-serde",
+ "bincode",
  "reth-chainspec",
  "reth-optimism-chainspec",
  "reth-optimism-forks",
@@ -6090,6 +6094,7 @@ dependencies = [
  "reth-trie",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ alloy-rpc-client = { version = "0.14.0", default-features = false }
 alloy-eips = { version = "0.14.0", default-features = false }
 alloy-rlp = "0.3.10"
 alloy-trie = "0.8.1"
+alloy-serde = "0.14.0"
 
 # op
 alloy-op-evm = { version = "0.4.0", default-features = false }

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -3801,8 +3801,11 @@ dependencies = [
 name = "rsp-primitives"
 version = "0.1.0"
 dependencies = [
+ "alloy-eips",
  "alloy-genesis",
+ "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-serde",
  "reth-chainspec",
  "reth-optimism-chainspec",
  "reth-optimism-forks",
@@ -3810,6 +3813,7 @@ dependencies = [
  "reth-trie",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 1.0.69",
 ]
 

--- a/bin/client/Cargo.lock
+++ b/bin/client/Cargo.lock
@@ -3591,13 +3591,17 @@ dependencies = [
 name = "rsp-primitives"
 version = "0.1.0"
 dependencies = [
+ "alloy-eips",
  "alloy-genesis",
+ "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-serde",
  "reth-chainspec",
  "reth-primitives-traits",
  "reth-trie",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 1.0.69",
 ]
 

--- a/bin/host/genesis/11155420.json
+++ b/bin/host/genesis/11155420.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "chainId": 11155420,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 7,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "arrowGlacierBlock": 0,
+    "grayGlacierBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "shanghaiTime": 1699981200,
+    "cancunTime": 1708534800,
+    "bedrockBlock": 0,
+    "regolithTime": 0,
+    "canyonTime": 1699981200,
+    "ecotoneTime": 1708534800,
+    "fjordTime": 1716998400,
+    "graniteTime": 1723478400,
+    "holoceneTime": 1732633200,
+    "pragueTime": 1741159776,
+    "isthmusTime": 1744905600,
+    "terminalTotalDifficulty": 0,
+    "depositContractAddress": "0x0000000000000000000000000000000000000000",
+    "optimism": {
+      "eip1559Elasticity": 6,
+      "eip1559Denominator": 50,
+      "eip1559DenominatorCanyon": 250
+    }
+  }
+}

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 serde.workspace = true
-serde_json = { workspace = true, features = ["raw_value"] }
+serde_json.workspace = true
 thiserror.workspace = true
 serde_with = "3.12.0"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -9,8 +9,9 @@ repository.workspace = true
 
 [dependencies]
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true
+serde_with = "3.12.0"
 
 # reth
 reth-primitives-traits.workspace = true
@@ -20,8 +21,17 @@ reth-optimism-forks = { workspace = true, optional = true }
 reth-trie.workspace = true
 
 # alloy
+alloy-primitives.workspace = true
+alloy-eips.workspace = true
 alloy-genesis.workspace = true
 alloy-rpc-types.workspace = true
+alloy-serde.workspace = true
+
+[dev-dependencies]
+bincode = "1.3.3"
 
 [features]
-optimism = ["dep:reth-optimism-chainspec", "dep:reth-optimism-forks"]
+optimism = [
+    "dep:reth-optimism-chainspec",
+    "dep:reth-optimism-forks",
+]

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -247,7 +247,6 @@ pub(crate) mod serde_bincode_compat {
             let mut extra_fields = OtherFields::default();
 
             for (k, v) in value.extra_fields {
-                println!("{k}: {v}");
                 extra_fields.insert(k, v.parse().unwrap());
             }
 

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -6,18 +6,21 @@ use std::{
 use alloy_genesis::ChainConfig;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, Chain, ChainSpec, EthereumHardfork};
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::error::ChainSpecError;
 
 pub const LINEA_GENESIS_JSON: &str = include_str!("../../../bin/host/genesis/59144.json");
+pub const OP_SEPOLIA_GENESIS_JSON: &str = include_str!("../../../bin/host/genesis/11155420.json");
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Genesis {
     Mainnet,
     OpMainnet,
     Sepolia,
     Linea,
-    Custom(ChainConfig),
+    Custom(#[serde_as(as = "serde_bincode_compat::ChainConfig")] ChainConfig),
 }
 
 impl Hash for Genesis {
@@ -150,5 +153,169 @@ impl TryFrom<&Genesis> for reth_optimism_chainspec::OpChainSpec {
             }
             _ => Err(ChainSpecError::InvalidConversion),
         }
+    }
+}
+
+pub(crate) mod serde_bincode_compat {
+    use std::collections::BTreeMap;
+
+    use alloy_eips::eip7840::BlobParams;
+    use alloy_genesis::{CliqueConfig, EthashConfig, ParliaConfig};
+    use alloy_primitives::{Address, U256};
+    use alloy_serde::OtherFields;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ChainConfig {
+        chain_id: u64,
+        homestead_block: Option<u64>,
+        dao_fork_block: Option<u64>,
+        dao_fork_support: bool,
+        eip150_block: Option<u64>,
+        eip155_block: Option<u64>,
+        eip158_block: Option<u64>,
+        byzantium_block: Option<u64>,
+        constantinople_block: Option<u64>,
+        petersburg_block: Option<u64>,
+        istanbul_block: Option<u64>,
+        muir_glacier_block: Option<u64>,
+        berlin_block: Option<u64>,
+        london_block: Option<u64>,
+        arrow_glacier_block: Option<u64>,
+        gray_glacier_block: Option<u64>,
+        merge_netsplit_block: Option<u64>,
+        shanghai_time: Option<u64>,
+        cancun_time: Option<u64>,
+        prague_time: Option<u64>,
+        osaka_time: Option<u64>,
+        terminal_total_difficulty: Option<U256>,
+        terminal_total_difficulty_passed: bool,
+        ethash: Option<EthashConfig>,
+        clique: Option<CliqueConfig>,
+        parlia: Option<ParliaConfig>,
+        extra_fields: BTreeMap<String, String>,
+        deposit_contract_address: Option<Address>,
+        blob_schedule: BTreeMap<String, BlobParams>,
+    }
+
+    impl From<&super::ChainConfig> for ChainConfig {
+        fn from(value: &super::ChainConfig) -> Self {
+            let mut extra_fields = BTreeMap::new();
+
+            for (k, v) in value.extra_fields.clone().into_iter() {
+                // We have to do this because bincode don't support serialize `serde_json::Value`
+                extra_fields.insert(k, v.to_string());
+            }
+
+            Self {
+                chain_id: value.chain_id,
+                homestead_block: value.homestead_block,
+                dao_fork_block: value.dao_fork_block,
+                dao_fork_support: value.dao_fork_support,
+                eip150_block: value.eip150_block,
+                eip155_block: value.eip155_block,
+                eip158_block: value.eip158_block,
+                byzantium_block: value.byzantium_block,
+                constantinople_block: value.constantinople_block,
+                petersburg_block: value.petersburg_block,
+                istanbul_block: value.istanbul_block,
+                muir_glacier_block: value.muir_glacier_block,
+                berlin_block: value.berlin_block,
+                london_block: value.london_block,
+                arrow_glacier_block: value.arrow_glacier_block,
+                gray_glacier_block: value.gray_glacier_block,
+                merge_netsplit_block: value.merge_netsplit_block,
+                shanghai_time: value.shanghai_time,
+                cancun_time: value.cancun_time,
+                prague_time: value.prague_time,
+                osaka_time: value.osaka_time,
+                terminal_total_difficulty: value.terminal_total_difficulty,
+                terminal_total_difficulty_passed: value.terminal_total_difficulty_passed,
+                ethash: value.ethash,
+                clique: value.clique,
+                parlia: value.parlia,
+                extra_fields,
+                deposit_contract_address: value.deposit_contract_address,
+                blob_schedule: value.blob_schedule.clone(),
+            }
+        }
+    }
+
+    impl From<ChainConfig> for super::ChainConfig {
+        fn from(value: ChainConfig) -> Self {
+            let mut extra_fields = OtherFields::default();
+
+            for (k, v) in value.extra_fields {
+                println!("{k}: {v}");
+                extra_fields.insert(k, v.parse().unwrap());
+            }
+
+            Self {
+                chain_id: value.chain_id,
+                homestead_block: value.homestead_block,
+                dao_fork_block: value.dao_fork_block,
+                dao_fork_support: value.dao_fork_support,
+                eip150_block: value.eip150_block,
+                eip155_block: value.eip155_block,
+                eip158_block: value.eip158_block,
+                byzantium_block: value.byzantium_block,
+                constantinople_block: value.constantinople_block,
+                petersburg_block: value.petersburg_block,
+                istanbul_block: value.istanbul_block,
+                muir_glacier_block: value.muir_glacier_block,
+                berlin_block: value.berlin_block,
+                london_block: value.london_block,
+                arrow_glacier_block: value.arrow_glacier_block,
+                gray_glacier_block: value.gray_glacier_block,
+                merge_netsplit_block: value.merge_netsplit_block,
+                shanghai_time: value.shanghai_time,
+                cancun_time: value.cancun_time,
+                prague_time: value.prague_time,
+                osaka_time: value.osaka_time,
+                terminal_total_difficulty: value.terminal_total_difficulty,
+                terminal_total_difficulty_passed: value.terminal_total_difficulty_passed,
+                ethash: value.ethash,
+                clique: value.clique,
+                parlia: value.parlia,
+                extra_fields,
+                deposit_contract_address: value.deposit_contract_address,
+                blob_schedule: value.blob_schedule,
+            }
+        }
+    }
+
+    impl SerializeAs<super::ChainConfig> for ChainConfig {
+        fn serialize_as<S>(source: &super::ChainConfig, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            ChainConfig::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeAs<'de, super::ChainConfig> for ChainConfig {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::ChainConfig, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            ChainConfig::deserialize(deserializer).map(Into::into)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::genesis::{genesis_from_json, Genesis, OP_SEPOLIA_GENESIS_JSON};
+
+    #[test]
+    fn test_custom_genesis_bincode_roundtrip() {
+        let alloy_genesis = genesis_from_json(OP_SEPOLIA_GENESIS_JSON).unwrap();
+        let genesis = Genesis::Custom(alloy_genesis.config);
+        let buf = bincode::serialize(&genesis).unwrap();
+        let deserialized = bincode::deserialize::<Genesis>(&buf).unwrap();
+
+        assert_eq!(genesis, deserialized);
     }
 }


### PR DESCRIPTION
The `ChainConfig` was failling to serialize with bincode because of Serde `flattern` and `skip_serializing_if` attributes. I created a private `serde_bincode_compat::ChainConfig` type without the attributes following the model from Alloy and Reth on bincode serialization.