### PR TITLE
Fix broken link to Generating proofs documentation

### DIFF
--- a/book/docs/02-Getting-started.md
+++ b/book/docs/02-Getting-started.md
@@ -31,4 +31,4 @@ When running RSP, you should see logs similar to:
 ...
 ```
 
-The host CLI executes the block while fetching additional data necessary for offline execution. The same execution and verification logic is then run inside the zkVM. No actual proof is generated from this command, but it will print out a detailed execution report. If you want to generate proofs, see [Generating proofs](./Generating-proofs).
+The host CLI executes the block while fetching additional data necessary for offline execution. The same execution and verification logic is then run inside the zkVM. No actual proof is generated from this command, but it will print out a detailed execution report. If you want to generate proofs, see [Generating proofs](./04-Generating-proofs.md).


### PR DESCRIPTION
This commit updates the broken link to the "Generating proofs" section in book/docs/02-Getting-started.md. The link now correctly points to ./04-Generating-proofs.md instead of the missing ./Generating-proofs file. This resolves the file not found error and ensures users can access the relevant documentation.