### PR TITLE
fix: order ancestor headers

### DIFF
--- a/crates/storage/rpc-db/src/execution_witness.rs
+++ b/crates/storage/rpc-db/src/execution_witness.rs
@@ -132,6 +132,8 @@ where
     }
 
     async fn ancestor_headers(&self) -> Result<Vec<Header>, RpcDbError> {
-        Ok(self.ancestor_headers.values().cloned().collect())
+        let mut ancestor_headers: Vec<Header> = self.ancestor_headers.values().cloned().collect();
+        ancestor_headers.sort_by(|a, b| b.number.cmp(&a.number));
+        Ok(ancestor_headers)
     }
 }


### PR DESCRIPTION
The ancestor headers must be ordered from most recent to older.