### PR TITLE
Readable Debug formatting for MPT nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6669,6 +6669,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-debug",
  "hex-literal",
+ "reth-primitives-traits",
  "reth-trie",
  "rlp",
  "serde",

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -26,6 +26,7 @@ alloy-rpc-types-debug = {workspace = true, optional = true }
 
 [dev-dependencies]
 hex-literal.workspace = true
+reth-primitives-traits.workspace = true
 
 [features]
 default = ["execution-witness"]

--- a/crates/mpt/examples/debug_print_state.rs
+++ b/crates/mpt/examples/debug_print_state.rs
@@ -40,5 +40,5 @@ fn main() {
     }
 
     // Print the full state - this will show Branch, Extension, Leaf nodes with cached references
-    println!("{:#?}", state);
+    println!("{state:#?}");
 }

--- a/crates/mpt/examples/debug_print_state.rs
+++ b/crates/mpt/examples/debug_print_state.rs
@@ -1,0 +1,44 @@
+use alloy_primitives::{map::HashMap, B256, U256};
+use reth_primitives_traits::Account;
+use reth_trie::{HashedPostState, HashedStorage};
+use rsp_mpt::EthereumState;
+
+fn main() {
+    // Create state with insertions that force ALL node types to appear
+    let mut state =
+        EthereumState { state_trie: Default::default(), storage_tries: HashMap::default() };
+
+    let mut post_state = HashedPostState::default();
+
+    // These specific addresses will create Branch, Extension, and Leaf nodes
+    post_state.accounts.insert(
+        B256::from([0xAA; 32]),
+        Some(Account { nonce: 1, balance: U256::from(1000), bytecode_hash: Some(B256::ZERO) }),
+    );
+    post_state.accounts.insert(
+        B256::from([0xBB; 32]),
+        Some(Account { nonce: 2, balance: U256::from(2000), bytecode_hash: Some(B256::ZERO) }),
+    );
+    post_state.accounts.insert(
+        B256::from([0xCC; 32]),
+        Some(Account { nonce: 3, balance: U256::from(3000), bytecode_hash: Some(B256::ZERO) }),
+    );
+
+    // Add storage to create storage tries with multiple slots
+    let mut storage = HashedStorage::new(false);
+    storage.storage.insert(B256::from([0x01; 32]), U256::from(100));
+    storage.storage.insert(B256::from([0x02; 32]), U256::from(200));
+    post_state.storages.insert(B256::from([0xAA; 32]), storage);
+
+    state.update(&post_state);
+
+    // Force reference computation by calling hash on the tries
+    // This populates the cached_reference field
+    let _state_root = state.state_root();
+    for storage in state.storage_tries.values() {
+        let _ = storage.hash();
+    }
+
+    // Print the full state - this will show Branch, Extension, Leaf nodes with cached references
+    println!("{:#?}", state);
+}

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -17,7 +17,7 @@ use mpt::{
 };
 
 /// Ethereum state trie and account storage tries.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EthereumState {
     pub state_trie: MptNode,
     pub storage_tries: HashMap<B256, MptNode>,
@@ -130,6 +130,18 @@ impl EthereumState {
     /// Computes the state root.
     pub fn state_root(&self) -> B256 {
         self.state_trie.hash()
+    }
+}
+
+impl core::fmt::Debug for EthereumState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("EthereumState");
+        ds.field("state_trie", &self.state_trie);
+
+        // Use BTreeMap for stable ordering when printing
+        let ordered: std::collections::BTreeMap<_, _> = self.storage_tries.iter().collect();
+        ds.field("storage_tries", &ordered);
+        ds.finish()
     }
 }
 

--- a/crates/mpt/src/mpt.rs
+++ b/crates/mpt/src/mpt.rs
@@ -237,7 +237,7 @@ impl core::fmt::Debug for MptNodeData {
                 let mut ds = f.debug_struct("Branch");
                 for (i, child) in children.iter().enumerate() {
                     if let Some(c) = child {
-                        ds.field(&format!("child_{}", i), c);
+                        ds.field(&format!("child_{i}"), c);
                     }
                 }
                 ds.finish()

--- a/crates/mpt/src/mpt.rs
+++ b/crates/mpt/src/mpt.rs
@@ -91,7 +91,7 @@ pub fn keccak(data: impl AsRef<[u8]>) -> [u8; 32] {
 /// optimizing storage. However, operations targeting a truncated part will fail and
 /// return an error. Another distinction of this implementation is that branches cannot
 /// store values, aligning with the construction of MPTs in Ethereum.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct MptNode {
     /// The type and data of the node.
     data: MptNodeData,
@@ -160,7 +160,7 @@ pub enum Error {
 /// Each node in the trie can be of one of several types, each with its own specific data
 /// structure. This enum provides a clear and type-safe way to represent the data
 /// associated with each node type.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum MptNodeData {
     /// Represents an empty trie node.
     #[default]
@@ -183,7 +183,7 @@ pub enum MptNodeData {
 /// Nodes in the MPT can reference other nodes either directly through their byte
 /// representation or indirectly through a hash of their encoding. This enum provides a
 /// clear and type-safe way to represent these references.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum MptNodeReference {
     /// Represents a direct reference to another node using its byte encoding. Typically
     /// used for short encodings that are less than 32 bytes in length.
@@ -201,6 +201,61 @@ pub enum MptNodeReference {
 impl From<MptNodeData> for MptNode {
     fn from(value: MptNodeData) -> Self {
         Self { data: value, cached_reference: Mutex::new(None) }
+    }
+}
+
+impl core::fmt::Debug for MptNodeReference {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            MptNodeReference::Bytes(b) => {
+                write!(f, "Ref::Bytes({})", alloy_primitives::hex::encode(b))
+            }
+            MptNodeReference::Digest(h) => {
+                write!(f, "Ref::Digest({})", alloy_primitives::hex::encode(h.as_slice()))
+            }
+        }
+    }
+}
+
+impl core::fmt::Debug for MptNodeData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            MptNodeData::Null => write!(f, "Null"),
+            MptNodeData::Leaf(k, v) => write!(
+                f,
+                "Leaf(key={}, value={})",
+                alloy_primitives::hex::encode(k),
+                alloy_primitives::hex::encode(v)
+            ),
+            MptNodeData::Extension(k, child) => f
+                .debug_struct("Extension")
+                .field("key", &alloy_primitives::hex::encode(k))
+                .field("child", child)
+                .finish(),
+            MptNodeData::Digest(h) => write!(f, "Digest({})", alloy_primitives::hex::encode(h)),
+            MptNodeData::Branch(children) => {
+                let mut ds = f.debug_struct("Branch");
+                for (i, child) in children.iter().enumerate() {
+                    if let Some(c) = child {
+                        ds.field(&format!("child_{}", i), c);
+                    }
+                }
+                ds.finish()
+            }
+        }
+    }
+}
+
+impl core::fmt::Debug for MptNode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("MptNode");
+        ds.field("data", &self.data);
+        if let Ok(guard) = self.cached_reference.lock() {
+            if let Some(reference) = guard.as_ref() {
+                ds.field("cached_reference", reference);
+            }
+        }
+        ds.finish()
     }
 }
 


### PR DESCRIPTION
## Summary

Add custom `Debug` implementations for MPT types and `EthereumState` to provide cleaner, more readable output with hex-encoded data.

## Motivation

I am getting rid of unused SP1/RSP code from my Ethereum prover codebase, and want to share some of the useful changes I made.

## Changes

- Implemented custom `Debug` for `MptNode`, `MptNodeData`, and `MptNodeReference`.
- Hex-encode all byte data (keys, values, hashes) for readability.
- Clearly label node types: `Null`, `Leaf`, `Branch`, `Extension`, `Digest`.
- Display cached references when available.
- Added example - `debug_print_state.rs` - demonstrating all MPT node variants.

## Benefits

- **More concise**: Hex strings instead of `[1, 2, 3, ...]` byte arrays.
- **No information loss**: All data is still present, just formatted better.
- **Easier debugging**: Node types and structure are immediately clear.

## Example Output

Before PR - **567 lines**:
- [debug_before.txt](https://github.com/user-attachments/files/22606513/debug_before.txt)

After PR - **46 lines**:

```
EthereumState {
    state_trie: MptNode {
        data: Branch {
            child_10: MptNode {
                data: Leaf(key=3aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, value=f846018203e8a061c53b685f978dd76f15ac807f453d211faec98a5c9151c97fa69b71cc80676ea00000000000000000000000000000000000000000000000000000000000000000),
                cached_reference: Ref::Digest(18c5b90a1baee6139a6b53d110745aedc176c1be96bfe6e9a90756c7841eb129),
            },
            child_11: MptNode {
                data: Leaf(key=3bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, value=f846028207d0a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00000000000000000000000000000000000000000000000000000000000000000),
                cached_reference: Ref::Digest(5019f4685eb8ebc24ab8165ff74b73fff01d22e74cbeed7177e47a7a130e9e04),
            },
            child_12: MptNode {
                data: Leaf(key=3ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc, value=f84603820bb8a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00000000000000000000000000000000000000000000000000000000000000000),
                cached_reference: Ref::Digest(71a39c6d42a16341be3fbf2a3bc66ece0ccabf16d7fc9dbe4988bc69b385aea7),
            },
        },
        cached_reference: Ref::Digest(e1a94ee6b8a36e248d8e73f94f3e1176e26cffe85b562928c079f8185f6353b4),
    },
    storage_tries: {
        0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: MptNode {
            data: Extension {
                key: "10",
                child: MptNode {
                    data: Branch {
                        child_1: MptNode {
                            data: Leaf(key=2001010101010101010101010101010101010101010101010101010101010101, value=64),
                            cached_reference: Ref::Digest(49b380f019d8be96be2b262a196f54a133c20e18cd45d19028c877a42e6a4a42),
                        },
                        child_2: MptNode {
                            data: Leaf(key=2002020202020202020202020202020202020202020202020202020202020202, value=81c8),
                            cached_reference: Ref::Digest(14158db8bc1544e5d96c7f790c9a790651ff4b50ade7f38636383cbf7952393c),
                        },
                    },
                    cached_reference: Ref::Digest(c7a05f0a47ec5eeb073ebf47bfafc5bdfcf49765630bea34cb8670169abfd279),
                },
            },
            cached_reference: Ref::Digest(61c53b685f978dd76f15ac807f453d211faec98a5c9151c97fa69b71cc80676e),
        },
        0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: MptNode {
            data: Null,
        },
        0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc: MptNode {
            data: Null,
        },
    },
}
```

The custom Debug output clearly shows the trie structure with labeled Branch/Leaf/Extension nodes and hex-encoded
data, while the before output is cluttered with verbose byte arrays.