### PR TITLE
Remove log_bloom form CSV report

### DIFF
--- a/bin/host/src/execute.rs
+++ b/bin/host/src/execute.rs
@@ -91,7 +91,6 @@ impl PersistExecutionReport {
             headers.push("recover_senders_cycles_count".to_string());
             headers.push("block_execution_cycles_count".to_string());
             headers.push("block_validation_cycles_count".to_string());
-            headers.push("accrue_logs_bloom_cycles_count".to_string());
             headers.push("state_root_computation_cycles_count".to_string());
             headers.push("syscalls_count".to_string());
             headers.push("prover_gas".to_string());


### PR DESCRIPTION
Fixes an error in 1dd3021ce37f81e963ba3be00744a74ffee71ca0 / #139, where log_bloom printing was removed but the header columns wasn't.