### PR TITLE
fix: correct article in error message

### DIFF
--- a/crates/executor/host/src/full_executor.rs
+++ b/crates/executor/host/src/full_executor.rs
@@ -47,7 +47,7 @@ where
         ));
     }
 
-    bail!("Either a RPC URL or a cache dir must be provided")
+    bail!("Either an RPC URL or a cache dir must be provided")
 }
 
 pub trait BlockExecutor<C: ExecutorComponents> {


### PR DESCRIPTION
## Description
Fixed grammatical error in error message.

⚠️ **Note:** Error message text only. No functional code modified. This is a minor documentation improvement.

## Changes
- Changed `a RPC` → `an RPC` in error message

## Files Modified
- crates/executor/host/src/full_executor.rs

## Impact
- Error message clarity improvement only
- No functional changes