### PR TITLE
feat(mpt): selectable arena MPT backend behind a StateTries trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,6 +6226,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "bumpalo",
  "itertools 0.13.0",
  "kzg-rs",
  "reth-chainspec",
@@ -6297,11 +6298,15 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-debug",
+ "bincode",
+ "bumpalo",
+ "bytes",
  "hex-literal",
  "reth-primitives-traits",
  "reth-trie",
  "rlp",
  "serde",
+ "smallvec",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ hex-literal = "0.4.1"
 rayon = "1.10.0"
 rlp = "0.5.2"
 
+# arena mpt
+bumpalo = { version = "3.19.0", features = ["collections"] }
+smallvec = "1.13"
+bytes = "1"
+
 # workspace
 rsp-rpc-db = { path = "./crates/storage/rpc-db" }
 rsp-witness-db = { path = "./crates/storage/witness-db" }

--- a/bin/client/Cargo.lock
+++ b/bin/client/Cargo.lock
@@ -3755,6 +3755,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "bumpalo",
  "itertools 0.13.0",
  "kzg-rs",
  "reth-chainspec",
@@ -3786,9 +3787,13 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-debug",
+ "bumpalo",
+ "bytes",
+ "reth-primitives-traits",
  "reth-trie",
  "rlp",
  "serde",
+ "smallvec",
  "thiserror 1.0.69",
 ]
 

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -17,6 +17,13 @@ sp1-zkvm = "=6.2.4"
 log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
+[features]
+default = []
+# Arena-based MPT backend (zero-copy witness read as a separate stdin item). Must be built to
+# match a host emitting the arena witness (`rsp-host-executor/arena`). The host binaries' build.rs
+# forwards this feature to the guest when they are built with their own `arena` feature.
+arena = ["rsp-client-executor/arena"]
+
 [patch.crates-io]
 # Precompile patches
 sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", tag = "patch-sha2-0.10.9-sp1-6.0.0", package = "sha2" }

--- a/bin/client/src/main.rs
+++ b/bin/client/src/main.rs
@@ -10,9 +10,26 @@ use std::sync::Arc;
 
 pub fn main() {
     // Read the input.
+    //
+    // Legacy backend: a single bincode item carrying the whole `EthClientExecutorInput`
+    // (including the pointer-based `EthereumState` in `parent_state`).
+    //
+    // Arena backend: the witness blob is a *separate* stdin item, so bincode only handles the
+    // small header (`parent_state` is `#[serde(skip)]`); the blob is then read straight from the
+    // SP1 input region into `input.parent_state` and decoded zero-copy in the executor.
     let input = profile_report!(DESERIALZE_INPUTS, {
-        let input = sp1_zkvm::io::read_vec();
-        bincode::deserialize::<EthClientExecutorInput>(&input).unwrap()
+        #[cfg(not(feature = "arena"))]
+        {
+            let input = sp1_zkvm::io::read_vec();
+            bincode::deserialize::<EthClientExecutorInput>(&input).unwrap()
+        }
+        #[cfg(feature = "arena")]
+        {
+            let header_bytes = sp1_zkvm::io::read_vec();
+            let mut input: EthClientExecutorInput = bincode::deserialize(&header_bytes).unwrap();
+            input.parent_state = sp1_zkvm::io::read_vec();
+            input
+        }
     });
 
     // Execute the block.

--- a/bin/continuous/Cargo.toml
+++ b/bin/continuous/Cargo.toml
@@ -30,9 +30,14 @@ alloy-rpc-client.workspace = true
 alloy-transport.workspace = true
 alloy-transport-ws.workspace = true
 
-# reth 
+# reth
 reth-evm.workspace = true
 reth-primitives-traits.workspace = true
+
+[features]
+# Select the arena-based (unaudited) MPT backend for both the host witness emission and the
+# `rsp-client` guest ELF (build.rs forwards this to the guest). Default is the legacy MPT.
+arena = ["rsp-host-executor/arena", "rsp-client-executor/arena"]
 
 [build-dependencies]
 sp1-build.workspace = true

--- a/bin/continuous/build.rs
+++ b/bin/continuous/build.rs
@@ -1,5 +1,13 @@
-use sp1_build::build_program;
+use sp1_build::{build_program_with_args, BuildArgs};
 
 fn main() {
-    build_program("../client");
+    // Build the `rsp-client` guest ELF. When this host binary is built with its own `arena`
+    // feature, cargo sets `CARGO_FEATURE_ARENA`; forward it to the guest so the ELF's MPT
+    // backend and witness codec match the host's (`rsp-host-executor/arena`).
+    let features = if std::env::var_os("CARGO_FEATURE_ARENA").is_some() {
+        vec!["arena".to_string()]
+    } else {
+        Vec::new()
+    };
+    build_program_with_args("../client", BuildArgs { features, ..Default::default() });
 }

--- a/bin/ethproofs/Cargo.toml
+++ b/bin/ethproofs/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { workspace = true, features = ["test-util"] }
 sp1-build.workspace = true
 
 [features]
-default = ["cuda", "arena"]
+default = ["cuda"]
 cuda = ["sp1-sdk/cuda", "rsp-host-executor/cuda"]
 # Select the arena-based (unaudited) MPT backend for both the host witness emission and the
 # `rsp-client` guest ELF (build.rs forwards this to the guest). Default is the legacy MPT.

--- a/bin/ethproofs/Cargo.toml
+++ b/bin/ethproofs/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { workspace = true, features = ["test-util"] }
 sp1-build.workspace = true
 
 [features]
-default = ["cuda"]
+default = ["cuda", "arena"]
 cuda = ["sp1-sdk/cuda", "rsp-host-executor/cuda"]
 # Select the arena-based (unaudited) MPT backend for both the host witness emission and the
 # `rsp-client` guest ELF (build.rs forwards this to the guest). Default is the legacy MPT.

--- a/bin/ethproofs/Cargo.toml
+++ b/bin/ethproofs/Cargo.toml
@@ -58,3 +58,6 @@ sp1-build.workspace = true
 [features]
 default = ["cuda"]
 cuda = ["sp1-sdk/cuda", "rsp-host-executor/cuda"]
+# Select the arena-based (unaudited) MPT backend for both the host witness emission and the
+# `rsp-client` guest ELF (build.rs forwards this to the guest). Default is the legacy MPT.
+arena = ["rsp-host-executor/arena", "rsp-client-executor/arena"]

--- a/bin/ethproofs/build.rs
+++ b/bin/ethproofs/build.rs
@@ -1,5 +1,13 @@
-use sp1_build::build_program;
+use sp1_build::{build_program_with_args, BuildArgs};
 
 fn main() {
-    build_program("../client");
+    // Build the `rsp-client` guest ELF. When this host binary is built with its own `arena`
+    // feature, cargo sets `CARGO_FEATURE_ARENA`; forward it to the guest so the ELF's MPT
+    // backend and witness codec match the host's (`rsp-host-executor/arena`).
+    let features = if std::env::var_os("CARGO_FEATURE_ARENA").is_some() {
+        vec!["arena".to_string()]
+    } else {
+        Vec::new()
+    };
+    build_program_with_args("../client", BuildArgs { features, ..Default::default() });
 }

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -46,5 +46,10 @@ serde_json = "1.0"
 thousands = "0.2.0"
 madato = "0.7.0"
 
+[features]
+# Select the arena-based (unaudited) MPT backend for both the host witness emission and the
+# `rsp-client` guest ELF (build.rs forwards this to the guest). Default is the legacy MPT.
+arena = ["rsp-host-executor/arena", "rsp-client-executor/arena"]
+
 [build-dependencies]
 sp1-build.workspace = true

--- a/bin/host/build.rs
+++ b/bin/host/build.rs
@@ -1,5 +1,13 @@
-use sp1_build::build_program;
+use sp1_build::{build_program_with_args, BuildArgs};
 
 fn main() {
-    build_program("../client");
+    // Build the `rsp-client` guest ELF. When this host binary is built with its own `arena`
+    // feature, cargo sets `CARGO_FEATURE_ARENA`; forward it to the guest so the ELF's MPT
+    // backend and witness codec match the host's (`rsp-host-executor/arena`).
+    let features = if std::env::var_os("CARGO_FEATURE_ARENA").is_some() {
+        vec!["arena".to_string()]
+    } else {
+        Vec::new()
+    };
+    build_program_with_args("../client", BuildArgs { features, ..Default::default() });
 }

--- a/crates/executor/client/Cargo.toml
+++ b/crates/executor/client/Cargo.toml
@@ -21,6 +21,9 @@ itertools = "0.13.0"
 rsp-mpt.workspace = true
 rsp-primitives.workspace = true
 
+# arena mpt (only used when the `arena` feature is enabled)
+bumpalo = { workspace = true, optional = true }
+
 # reth
 reth-consensus.workspace = true
 reth-consensus-common.workspace = true
@@ -51,3 +54,7 @@ alloy-rlp.workspace = true
 default = ["sha3-keccak"]
 sha3-keccak = ["alloy-primitives/sha3-keccak"]
 native-keccak = ["alloy-primitives/native-keccak"]
+# Select the arena-based MPT backend (zero-copy witness) instead of the default pointer-based
+# `EthereumState` MPT. Switches the witness codec, the guest stdin reading, and the trie backend
+# together (host + guest must agree). The arena MPT is not yet audited — opt-in only.
+arena = ["dep:bumpalo"]

--- a/crates/executor/client/src/executor.rs
+++ b/crates/executor/client/src/executor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use alloy_consensus::{BlockHeader, Header};
+use alloy_evm::Database;
 use itertools::Itertools;
 use reth_chainspec::ChainSpec;
 use reth_errors::BlockExecutionError;
@@ -19,7 +20,7 @@ use crate::{
     custom::{CustomCrypto, CustomEvmFactory},
     error::ClientError,
     into_primitives::FromInput,
-    io::{ClientExecutorInput, TrieDB, WitnessInput},
+    io::{ClientExecutorInput, WitnessInput},
     tracking::OpCodesTrackingBlockExecutor,
     BlockValidator,
 };
@@ -46,15 +47,29 @@ where
     C: ConfigureEvm,
     C::Primitives: FromInput + BlockValidator<CS>,
 {
+    // Under the `arena` backend `input` is only ever read (the tries live in a separate
+    // bump-scoped value), so the `mut` binding needed by the legacy in-place update is unused.
+    #[cfg_attr(feature = "arena", allow(unused_mut))]
     pub fn execute(
         &self,
         mut input: ClientExecutorInput<C::Primitives>,
     ) -> Result<Header, ClientError> {
         let sealed_headers = input.sealed_headers().collect::<Vec<_>>();
 
+        // Decode the arena witness into bump-scoped tries (zero-copy, hash-verifying). The bump
+        // and the decoded tries live for the whole function so the witness DB can borrow them;
+        // `tries` is mutated by the post-execution state update.
+        #[cfg(feature = "arena")]
+        let bump = bumpalo::Bump::new();
+        #[cfg(feature = "arena")]
+        let mut tries = input.tries(&bump).unwrap();
+
         // Initialize the witnessed database with verified storage proofs.
         let db = profile_report!(INIT_WITNESS_DB, {
+            #[cfg(not(feature = "arena"))]
             let trie_db = input.witness_db(&sealed_headers).unwrap();
+            #[cfg(feature = "arena")]
+            let trie_db = input.witness_db(&tries, &sealed_headers).unwrap();
             WrapDatabaseRef(trie_db)
         });
 
@@ -105,9 +120,25 @@ where
         );
 
         // Verify the state root.
+        //
+        // SOUNDNESS: this final state-root check is load-bearing for every host-controlled value
+        // that flows into the tries — not just the trie nodes (whose hashes are verified during
+        // decode), but also, on the arena backend, the untrusted `pre_state_storage_roots` cache
+        // consumed by `ArenaTries::update` (see the `SOUNDNESS:` docs on
+        // `EthereumState::to_arena_witness` / `ArenaTries`). A tampered witness input surfaces
+        // here as `MismatchedStateRoot` and no proof is produced.
         let state_root = profile_report!(COMPUTE_STATE_ROOT, {
-            input.parent_state.update(&executor_outcome.hash_state_slow::<KeccakKeyHasher>());
-            input.parent_state.state_root()
+            let post_state = executor_outcome.hash_state_slow::<KeccakKeyHasher>();
+            #[cfg(not(feature = "arena"))]
+            {
+                input.parent_state.update(&post_state);
+                input.parent_state.state_root()
+            }
+            #[cfg(feature = "arena")]
+            {
+                tries.update(&post_state);
+                tries.state_root()
+            }
         });
 
         if state_root != input.current_block.header().state_root() {
@@ -160,13 +191,15 @@ impl EthClientExecutor {
     }
 }
 
-enum BlockExecutor<'a, C> {
-    Basic(BasicBlockExecutor<C, WrapDatabaseRef<TrieDB<'a>>>),
-    OpcodeTracking(OpCodesTrackingBlockExecutor<C, WrapDatabaseRef<TrieDB<'a>>>),
+/// Dispatches block execution to either the basic or opcode-tracking executor. Generic over the
+/// revm database `DB`, so it is agnostic to which state-trie backend (legacy or arena) built it.
+enum BlockExecutor<C, DB> {
+    Basic(BasicBlockExecutor<C, DB>),
+    OpcodeTracking(OpCodesTrackingBlockExecutor<C, DB>),
 }
 
-impl<'a, C: ConfigureEvm> BlockExecutor<'a, C> {
-    fn new(strategy_factory: C, db: WrapDatabaseRef<TrieDB<'a>>, opcode_tracking: bool) -> Self {
+impl<C: ConfigureEvm, DB: Database> BlockExecutor<C, DB> {
+    fn new(strategy_factory: C, db: DB, opcode_tracking: bool) -> Self {
         if opcode_tracking {
             Self::OpcodeTracking(OpCodesTrackingBlockExecutor::new(strategy_factory, db))
         } else {
@@ -175,9 +208,10 @@ impl<'a, C: ConfigureEvm> BlockExecutor<'a, C> {
     }
 }
 
-impl<'a, C> Executor<WrapDatabaseRef<TrieDB<'a>>> for BlockExecutor<'a, C>
+impl<C, DB> Executor<DB> for BlockExecutor<C, DB>
 where
     C: ConfigureEvm,
+    DB: Database,
 {
     type Primitives = C::Primitives;
     type Error = BlockExecutionError;
@@ -226,7 +260,7 @@ where
         }
     }
 
-    fn into_state(self) -> revm::database::State<WrapDatabaseRef<TrieDB<'a>>> {
+    fn into_state(self) -> revm::database::State<DB> {
         match self {
             BlockExecutor::Basic(basic_block_executor) => basic_block_executor.into_state(),
             BlockExecutor::OpcodeTracking(op_codes_tracking_block_executor) => {

--- a/crates/executor/client/src/io.rs
+++ b/crates/executor/client/src/io.rs
@@ -6,16 +6,21 @@ use itertools::Itertools;
 use reth_errors::ProviderError;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
-use reth_trie::{TrieAccount, EMPTY_ROOT_HASH};
+use reth_trie::EMPTY_ROOT_HASH;
 use revm::{
     state::{AccountInfo, Bytecode},
     DatabaseRef,
 };
 use revm_primitives::{keccak256, Address, B256, U256};
-use rsp_mpt::EthereumState;
+use rsp_mpt::StateTries;
 use rsp_primitives::genesis::Genesis;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+
+#[cfg(not(feature = "arena"))]
+use rsp_mpt::EthereumState;
+#[cfg(feature = "arena")]
+use {bumpalo::Bump, rsp_mpt::ArenaTries};
 
 use crate::error::ClientError;
 
@@ -71,7 +76,18 @@ pub struct ClientExecutorInput<P: NodePrimitives> {
     #[serde_as(as = "Vec<alloy_consensus::serde_bincode_compat::Header>")]
     pub ancestor_headers: Vec<Header>,
     /// Network state as of the parent block.
+    ///
+    /// - default (legacy) backend: the full [`EthereumState`] (pointer-based MPT), serialized
+    ///   inline via bincode.
+    /// - `arena` backend: the arena-codec witness blob, shipped as a *separate* SP1 stdin item and
+    ///   `#[serde(skip)]`ped here so bincode only handles the small header; the guest fills this
+    ///   field from `sp1_zkvm::io::read_vec()` before executing and decodes it zero-copy (see
+    ///   [`ArenaTries::decode`]).
+    #[cfg(not(feature = "arena"))]
     pub parent_state: EthereumState,
+    #[cfg(feature = "arena")]
+    #[serde(skip, default)]
+    pub parent_state: Vec<u8>,
     /// Account bytecodes.
     pub bytecodes: Vec<Bytecode>,
     /// The genesis block, as a json string.
@@ -89,18 +105,38 @@ impl<P: NodePrimitives> ClientExecutorInput<P> {
         &self.ancestor_headers[0]
     }
 
-    /// Creates a [`WitnessDb`].
-    pub fn witness_db(&self, sealed_headers: &[SealedHeader]) -> Result<TrieDB<'_>, ClientError> {
-        <Self as WitnessInput>::witness_db(self, sealed_headers)
+    /// Creates a [`TrieDB`] backed by the legacy pointer-based [`EthereumState`].
+    #[cfg(not(feature = "arena"))]
+    #[inline(always)]
+    pub fn witness_db(
+        &self,
+        sealed_headers: &[SealedHeader],
+    ) -> Result<TrieDB<'_, EthereumState>, ClientError> {
+        build_trie_db(&self.parent_state, self.state_anchor(), self.bytecodes(), sealed_headers)
+    }
+
+    /// Decodes the arena witness blob into bump-scoped tries (zero-copy, hash-verifying). The
+    /// bump and returned tries must outlive the [`TrieDB`] built from them by
+    /// [`Self::witness_db`].
+    #[cfg(feature = "arena")]
+    #[inline(always)]
+    pub fn tries<'a>(&'a self, bump: &'a Bump) -> Result<ArenaTries<'a>, ClientError> {
+        ArenaTries::decode(bump, &self.parent_state).map_err(|_| ClientError::MismatchedStateRoot)
+    }
+
+    /// Creates a [`TrieDB`] backed by the arena tries decoded via [`Self::tries`].
+    #[cfg(feature = "arena")]
+    #[inline(always)]
+    pub fn witness_db<'a, 'b>(
+        &'a self,
+        tries: &'a ArenaTries<'b>,
+        sealed_headers: &[SealedHeader],
+    ) -> Result<TrieDB<'a, ArenaTries<'b>>, ClientError> {
+        build_trie_db(tries, self.state_anchor(), self.bytecodes(), sealed_headers)
     }
 }
 
 impl<P: NodePrimitives> WitnessInput for ClientExecutorInput<P> {
-    #[inline(always)]
-    fn state(&self) -> &EthereumState {
-        &self.parent_state
-    }
-
     #[inline(always)]
     fn state_anchor(&self) -> B256 {
         self.parent_header().state_root()
@@ -132,16 +168,18 @@ impl From<Header> for CommittedHeader {
     }
 }
 
+/// Witness-backed database revm reads from during execution. Generic over the state-trie backend
+/// `T` (the legacy [`EthereumState`] or the arena [`ArenaTries`]) via the [`StateTries`] trait.
 #[derive(Debug)]
-pub struct TrieDB<'a> {
-    inner: &'a EthereumState,
+pub struct TrieDB<'a, T: StateTries> {
+    inner: &'a T,
     block_hashes: HashMap<u64, B256>,
     bytecode_by_hash: HashMap<B256, &'a Bytecode>,
 }
 
-impl<'a> TrieDB<'a> {
+impl<'a, T: StateTries> TrieDB<'a, T> {
     pub fn new(
-        inner: &'a EthereumState,
+        inner: &'a T,
         block_hashes: HashMap<u64, B256>,
         bytecode_by_hash: HashMap<B256, &'a Bytecode>,
     ) -> Self {
@@ -149,16 +187,13 @@ impl<'a> TrieDB<'a> {
     }
 }
 
-impl DatabaseRef for TrieDB<'_> {
+impl<T: StateTries> DatabaseRef for TrieDB<'_, T> {
     /// The database error type.
     type Error = ProviderError;
 
     /// Get basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let hashed_address = keccak256(address);
-        let hashed_address = hashed_address.as_slice();
-
-        let account_in_trie = self.inner.state_trie.get_rlp::<TrieAccount>(hashed_address).unwrap();
+        let account_in_trie = self.inner.account(keccak256(address));
 
         let account = account_in_trie.map(|account_in_trie| AccountInfo {
             balance: account_in_trie.balance,
@@ -178,19 +213,7 @@ impl DatabaseRef for TrieDB<'_> {
 
     /// Get storage value of address at index.
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let hashed_address = keccak256(address);
-        let hashed_address = hashed_address.as_slice();
-
-        let storage_trie = self
-            .inner
-            .storage_tries
-            .get(hashed_address)
-            .expect("A storage trie must be provided for each account");
-
-        Ok(storage_trie
-            .get_rlp::<U256>(keccak256(index.to_be_bytes::<32>()).as_slice())
-            .expect("Can get from MPT")
-            .unwrap_or_default())
+        Ok(self.inner.storage_value(keccak256(address), keccak256(index.to_be_bytes::<32>())))
     }
 
     /// Get block hash by block number.
@@ -202,13 +225,61 @@ impl DatabaseRef for TrieDB<'_> {
     }
 }
 
-/// A trait for constructing [`WitnessDb`].
-pub trait WitnessInput {
-    /// Gets a reference to the state from which account info and storage slots are loaded.
-    fn state(&self) -> &EthereumState;
+/// Verifies the state/storage roots, ancestor headers and account bytecodes of a [`StateTries`]
+/// backend, and constructs the [`TrieDB`] revm reads against during execution.
+///
+/// NOTE: For some unknown reasons, calling this via a bare trait method (rather than from a method
+/// on the input type) causes a zkVM run to cost over 5M cycles more. The per-backend `witness_db`
+/// inherent methods on [`ClientExecutorInput`] preserve that call shape.
+#[inline(always)]
+fn build_trie_db<'a, T: StateTries>(
+    tries: &'a T,
+    state_anchor: B256,
+    bytecodes: impl Iterator<Item = &'a Bytecode>,
+    sealed_headers: &[SealedHeader],
+) -> Result<TrieDB<'a, T>, ClientError> {
+    if state_anchor != tries.state_root() {
+        return Err(ClientError::MismatchedStateRoot);
+    }
 
-    /// Gets the state trie root hash that the state referenced by
-    /// [state()](trait.WitnessInput#tymethod.state) must conform to.
+    for (hashed_address, storage_root) in tries.storage_roots() {
+        let account_storage_root =
+            tries.account(hashed_address).map_or(EMPTY_ROOT_HASH, |a| a.storage_root);
+        if account_storage_root != storage_root {
+            return Err(ClientError::MismatchedStorageRoot);
+        }
+    }
+
+    let bytecodes_by_hash =
+        bytecodes.map(|code| (code.hash_slow(), code)).collect::<HashMap<_, _>>();
+
+    // Verify and build block hashes
+    let mut block_hashes: HashMap<u64, B256> = HashMap::with_hasher(Default::default());
+    for (child_header, parent_header) in sealed_headers.iter().tuple_windows() {
+        if parent_header.number() != child_header.number() - 1 {
+            return Err(ClientError::InvalidHeaderBlockNumber(
+                parent_header.number() + 1,
+                child_header.number(),
+            ));
+        }
+
+        let parent_header_hash = parent_header.hash();
+        if parent_header_hash != child_header.parent_hash() {
+            return Err(ClientError::InvalidHeaderParentHash(
+                parent_header_hash,
+                child_header.parent_hash(),
+            ));
+        }
+
+        block_hashes.insert(parent_header.number(), child_header.parent_hash());
+    }
+
+    Ok(TrieDB::new(tries, block_hashes, bytecodes_by_hash))
+}
+
+/// A trait for the backend-independent inputs used to construct a [`TrieDB`].
+pub trait WitnessInput {
+    /// Gets the state trie root hash that the backing state must conform to.
     fn state_anchor(&self) -> B256;
 
     /// Gets an iterator over account bytecodes.
@@ -217,55 +288,4 @@ pub trait WitnessInput {
     /// Gets an iterator over references to a consecutive, reverse-chronological block headers
     /// starting from the current block header.
     fn sealed_headers(&self) -> impl Iterator<Item = SealedHeader>;
-
-    /// Creates a [`WitnessDb`] from a [`WitnessInput`] implementation. To do so, it verifies the
-    /// state root, ancestor headers and account bytecodes, and constructs the account and
-    /// storage values by reading against state tries.
-    ///
-    /// NOTE: For some unknown reasons, calling this trait method directly from outside of the type
-    /// implementing this trait causes a zkVM run to cost over 5M cycles more. To avoid this, define
-    /// a method inside the type that calls this trait method instead.
-    #[inline(always)]
-    fn witness_db(&self, sealed_headers: &[SealedHeader]) -> Result<TrieDB<'_>, ClientError> {
-        let state = self.state();
-
-        if self.state_anchor() != state.state_root() {
-            return Err(ClientError::MismatchedStateRoot);
-        }
-
-        for (hashed_address, storage_trie) in state.storage_tries.iter() {
-            let account =
-                state.state_trie.get_rlp::<TrieAccount>(hashed_address.as_slice()).unwrap();
-            let storage_root = account.map_or(EMPTY_ROOT_HASH, |a| a.storage_root);
-            if storage_root != storage_trie.hash() {
-                return Err(ClientError::MismatchedStorageRoot);
-            }
-        }
-
-        let bytecodes_by_hash =
-            self.bytecodes().map(|code| (code.hash_slow(), code)).collect::<HashMap<_, _>>();
-
-        // Verify and build block hashes
-        let mut block_hashes: HashMap<u64, B256> = HashMap::with_hasher(Default::default());
-        for (child_header, parent_header) in sealed_headers.iter().tuple_windows() {
-            if parent_header.number() != child_header.number() - 1 {
-                return Err(ClientError::InvalidHeaderBlockNumber(
-                    parent_header.number() + 1,
-                    child_header.number(),
-                ));
-            }
-
-            let parent_header_hash = parent_header.hash();
-            if parent_header_hash != child_header.parent_hash() {
-                return Err(ClientError::InvalidHeaderParentHash(
-                    parent_header_hash,
-                    child_header.parent_hash(),
-                ));
-            }
-
-            block_hashes.insert(parent_header.number(), child_header.parent_hash());
-        }
-
-        Ok(TrieDB::new(state, block_hashes, bytecodes_by_hash))
-    }
 }

--- a/crates/executor/host/Cargo.toml
+++ b/crates/executor/host/Cargo.toml
@@ -68,3 +68,6 @@ dotenv = "0.15.0"
 [features]
 cuda = ["sp1-sdk/cuda"]
 alerting = ["dep:reqwest"]
+# Emit the arena-codec witness (zero-copy) instead of the default bincode `EthereumState`.
+# Must match how the `rsp-client` guest ELF is built (see the host binaries' build.rs).
+arena = ["rsp-client-executor/arena"]

--- a/crates/executor/host/src/full_executor.rs
+++ b/crates/executor/host/src/full_executor.rs
@@ -59,12 +59,18 @@ pub trait BlockExecutor<C: ExecutorComponents> {
     fn config(&self) -> &Config;
 
     /// Serialize a client input into zkVM stdin.
+    ///
+    /// Under the `arena` backend the witness blob (`client_input.parent_state`) is
+    /// `#[serde(skip)]`ped by bincode and sent as a *separate* stdin item, so the guest can decode
+    /// it zero-copy by borrowing the input region directly — see `bin/client/src/main.rs`.
     fn build_stdin(
         &self,
         client_input: &ClientExecutorInput<C::Primitives>,
     ) -> eyre::Result<SP1Stdin> {
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(bincode::serialize(client_input)?);
+        #[cfg(feature = "arena")]
+        stdin.write_vec(client_input.parent_state.clone());
         Ok(stdin)
     }
 

--- a/crates/executor/host/src/host_executor.rs
+++ b/crates/executor/host/src/host_executor.rs
@@ -249,11 +249,18 @@ impl<C: ConfigureEvm, CS> HostExecutor<C, CS> {
             state_root
         );
 
-        // Create the client input.
+        // Create the client input. The host always builds the pointer-based `EthereumState`;
+        // under the `arena` backend it is re-encoded into the flat arena-codec witness blob that
+        // the guest decodes zero-copy (the `parent_state` field is `Vec<u8>` in that config).
+        #[cfg(not(feature = "arena"))]
+        let parent_state = state;
+        #[cfg(feature = "arena")]
+        let parent_state = state.to_arena_witness();
+
         let client_input = ClientExecutorInput {
             current_block: C::Primitives::into_input_block(current_block),
             ancestor_headers,
-            parent_state: state,
+            parent_state,
             bytecodes: rpc_db.bytecodes(),
             genesis,
             custom_beneficiary,

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 thiserror.workspace = true
 
 # reth
+reth-primitives-traits.workspace = true
 reth-trie.workspace = true
 
 # alloy
@@ -24,9 +25,14 @@ alloy-rlp.workspace = true
 alloy-rpc-types.workspace = true
 alloy-rpc-types-debug = {workspace = true, optional = true }
 
+# arena mpt
+bumpalo.workspace = true
+smallvec.workspace = true
+bytes.workspace = true
+
 [dev-dependencies]
 hex-literal.workspace = true
-reth-primitives-traits.workspace = true
+bincode = "1.3"
 
 [features]
 default = ["execution-witness"]

--- a/crates/mpt/examples/bench_arena_mpt.rs
+++ b/crates/mpt/examples/bench_arena_mpt.rs
@@ -1,0 +1,309 @@
+//! Benchmark: legacy pointer-based `MptNode` vs. the arena-based `arena::Mpt`.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run --release --example bench_arena_mpt -p rsp-mpt
+//! ```
+//!
+//! There is no SP1 toolchain in scope here, so this cannot report true zkVM cycle counts.
+//! Instead it reports two host-side proxies:
+//!
+//! * wall-clock time (min of several runs), and
+//! * heap allocation count / bytes via a counting global allocator.
+//!
+//! Neither proxy is a substitute for a real SP1 cycle count, and they can even disagree with it:
+//! native wall-time benefits from SIMD/`memcpy` that the RISC-V zkVM does not have, while the
+//! allocation count's weight depends on SP1's guest allocator. Treat the allocation *count* as
+//! the structural signal (the arena design removes per-node allocation entirely) and the
+//! definitive comparison as a follow-up `cargo prove` cycle measurement.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+    time::Instant,
+};
+
+use alloy_primitives::{keccak256, B256};
+use rsp_mpt::{arena::Mpt, MptNode};
+
+// ---------------------------------------------------------------------------
+// Counting global allocator
+// ---------------------------------------------------------------------------
+
+struct CountingAlloc;
+
+static ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Relaxed);
+        BYTES_ALLOCATED.fetch_add(layout.size() as u64, Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Relaxed);
+        if new_size > layout.size() {
+            BYTES_ALLOCATED.fetch_add((new_size - layout.size()) as u64, Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+#[derive(Clone, Copy)]
+struct Stats {
+    allocs: u64,
+    bytes: u64,
+}
+
+fn snapshot() -> Stats {
+    Stats { allocs: ALLOC_COUNT.load(Relaxed), bytes: BYTES_ALLOCATED.load(Relaxed) }
+}
+
+/// Runs `f`, returning `(result, allocations during f, bytes allocated during f)`.
+fn measure_allocs<R>(f: impl FnOnce() -> R) -> (R, Stats) {
+    let before = snapshot();
+    let r = f();
+    let after = snapshot();
+    (r, Stats { allocs: after.allocs - before.allocs, bytes: after.bytes - before.bytes })
+}
+
+/// Returns the minimum wall-clock duration of `iters` runs of `f`, in microseconds.
+fn min_time_us(iters: u32, mut f: impl FnMut()) -> u128 {
+    let mut best = u128::MAX;
+    for _ in 0..iters {
+        let t = Instant::now();
+        f();
+        best = best.min(t.elapsed().as_micros());
+    }
+    best
+}
+
+// ---------------------------------------------------------------------------
+// Workload
+// ---------------------------------------------------------------------------
+
+const N: usize = 5_000;
+const TIME_ITERS: u32 = 7;
+
+/// Deterministic, keccak-hashed 32-byte keys, like hashed account addresses / storage slots.
+fn keys() -> Vec<B256> {
+    (0..N as u64).map(|i| keccak256(i.to_be_bytes())).collect()
+}
+
+fn main() {
+    let keys = keys();
+
+    println!("Arena MPT benchmark  (N = {N} keccak-keyed entries)\n");
+
+    // --- correctness cross-check: both implementations must agree on the root hash ---
+    let legacy_root = {
+        let mut t = MptNode::default();
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        t.hash()
+    };
+    let arena_root = {
+        let bump = bumpalo::Bump::new();
+        let mut t = Mpt::new(&bump);
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        t.hash()
+    };
+    assert_eq!(legacy_root, arena_root, "root hash mismatch between implementations");
+    println!("root hashes agree: {legacy_root}\n");
+
+    // --- BUILD (insert N + compute root hash) ---
+    let (_, legacy_build) = measure_allocs(|| {
+        let mut t = MptNode::default();
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        t.hash()
+    });
+    let (_, arena_build) = measure_allocs(|| {
+        let bump = bumpalo::Bump::new();
+        let mut t = Mpt::new(&bump);
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        t.hash()
+    });
+    let legacy_build_t = min_time_us(TIME_ITERS, || {
+        let mut t = MptNode::default();
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        std::hint::black_box(t.hash());
+    });
+    let arena_build_t = min_time_us(TIME_ITERS, || {
+        let bump = bumpalo::Bump::new();
+        let mut t = Mpt::new(&bump);
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        std::hint::black_box(t.hash());
+    });
+
+    // --- GET (look up all N keys) ---
+    let legacy_get_t;
+    let arena_get_t;
+    let legacy_get;
+    let arena_get;
+    {
+        let mut legacy = MptNode::default();
+        for (i, k) in keys.iter().enumerate() {
+            legacy.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        (_, legacy_get) = measure_allocs(|| {
+            for k in &keys {
+                std::hint::black_box(legacy.get_rlp::<u64>(k.as_slice()).unwrap());
+            }
+        });
+        legacy_get_t = min_time_us(TIME_ITERS, || {
+            for k in &keys {
+                std::hint::black_box(legacy.get_rlp::<u64>(k.as_slice()).unwrap());
+            }
+        });
+
+        let bump = bumpalo::Bump::new();
+        let mut arena = Mpt::new(&bump);
+        for (i, k) in keys.iter().enumerate() {
+            arena.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        (_, arena_get) = measure_allocs(|| {
+            for k in &keys {
+                std::hint::black_box(arena.get_rlp::<u64>(k.as_slice()).unwrap());
+            }
+        });
+        arena_get_t = min_time_us(TIME_ITERS, || {
+            for k in &keys {
+                std::hint::black_box(arena.get_rlp::<u64>(k.as_slice()).unwrap());
+            }
+        });
+    }
+
+    // --- DELETE (remove all N keys) ---
+    // The trie is built first (outside the measured region), then deletion is measured alone.
+    let legacy_del = {
+        let mut t = MptNode::default();
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        let (_, s) = measure_allocs(|| {
+            for k in &keys {
+                t.delete(k.as_slice()).unwrap();
+            }
+        });
+        s
+    };
+    let arena_del = {
+        let bump = bumpalo::Bump::new();
+        let mut t = Mpt::new(&bump);
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        let (_, s) = measure_allocs(|| {
+            for k in &keys {
+                t.delete(k.as_slice()).unwrap();
+            }
+        });
+        s
+    };
+
+    // --- ENCODE / DECODE (witness serialization round-trip) ---
+    let arena_encdec = {
+        let bump = bumpalo::Bump::new();
+        let mut t = Mpt::new(&bump);
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        let num_nodes = t.num_nodes();
+        let encoded = t.encode_trie();
+        let bump2 = bumpalo::Bump::new();
+        let (_, s) = measure_allocs(|| {
+            let mut slice = encoded.as_slice();
+            let decoded = Mpt::decode_trie(&bump2, &mut slice, num_nodes).unwrap();
+            std::hint::black_box(decoded.hash());
+        });
+        (encoded.len(), s)
+    };
+    // The legacy trie is serialized the way RSP actually ships it in the witness: serde over
+    // the whole node tree (here via bincode). NOTE: `alloy_rlp::encode` would NOT work as a
+    // whole-trie encoding -- it emits only the root node with 32-byte digest child references.
+    let legacy_encdec = {
+        let mut t = MptNode::default();
+        for (i, k) in keys.iter().enumerate() {
+            t.insert_rlp(k.as_slice(), i as u64).unwrap();
+        }
+        let encoded = bincode::serialize(&t).unwrap();
+        let (_, s) = measure_allocs(|| {
+            let decoded: MptNode = bincode::deserialize(&encoded).unwrap();
+            std::hint::black_box(decoded.hash());
+        });
+        (encoded.len(), s)
+    };
+
+    // --- report ---
+    print_phase(
+        "BUILD  (insert N + hash)",
+        legacy_build,
+        legacy_build_t,
+        arena_build,
+        arena_build_t,
+    );
+    print_phase("GET    (lookup N)", legacy_get, legacy_get_t, arena_get, arena_get_t);
+    print_phase_no_time("DELETE (remove N)", legacy_del, arena_del);
+
+    println!("\nDECODE (witness deserialization round-trip)");
+    println!(
+        "  legacy : encoded {:>7} B   {:>9} allocs   {:>10} B allocated",
+        legacy_encdec.0, legacy_encdec.1.allocs, legacy_encdec.1.bytes
+    );
+    println!(
+        "  arena  : encoded {:>7} B   {:>9} allocs   {:>10} B allocated",
+        arena_encdec.0, arena_encdec.1.allocs, arena_encdec.1.bytes
+    );
+}
+
+fn print_phase(name: &str, l: Stats, lt: u128, a: Stats, at: u128) {
+    println!("{name}");
+    println!("  legacy : {:>9} allocs   {:>11} B allocated   {:>8} us", l.allocs, l.bytes, lt);
+    println!("  arena  : {:>9} allocs   {:>11} B allocated   {:>8} us", a.allocs, a.bytes, at);
+    println!(
+        "  ratio  : {:>8.1}x fewer allocs   {:>8.1}x fewer bytes   {:>7.1}x faster\n",
+        ratio(l.allocs, a.allocs),
+        ratio(l.bytes, a.bytes),
+        ratio(lt as u64, at as u64),
+    );
+}
+
+fn print_phase_no_time(name: &str, l: Stats, a: Stats) {
+    println!("{name}");
+    println!("  legacy : {:>9} allocs   {:>11} B allocated", l.allocs, l.bytes);
+    println!("  arena  : {:>9} allocs   {:>11} B allocated", a.allocs, a.bytes);
+    println!(
+        "  ratio  : {:>8.1}x fewer allocs   {:>8.1}x fewer bytes\n",
+        ratio(l.allocs, a.allocs),
+        ratio(l.bytes, a.bytes),
+    );
+}
+
+fn ratio(legacy: u64, arena: u64) -> f64 {
+    if arena == 0 {
+        f64::INFINITY
+    } else {
+        legacy as f64 / arena as f64
+    }
+}

--- a/crates/mpt/src/arena/bump_bufmut.rs
+++ b/crates/mpt/src/arena/bump_bufmut.rs
@@ -1,0 +1,101 @@
+use bumpalo::Bump;
+use bytes::{buf::UninitSlice, BufMut, TryGetError};
+
+fn panic_advance(error_info: &TryGetError) -> ! {
+    panic!(
+        "advance out of bounds: the len is {} but advancing by {}",
+        error_info.available, error_info.requested
+    );
+}
+
+/// A helper type to implement bytes::BufMut for bumpalo::collections::Vec<'a, u8>.
+pub(crate) struct BumpBytesMut<'a> {
+    inner: bumpalo::collections::Vec<'a, u8>,
+}
+
+impl<'a> BumpBytesMut<'a> {
+    #[inline(always)]
+    pub(crate) fn with_capacity_in(capacity: usize, bump: &'a Bump) -> Self {
+        Self { inner: bumpalo::collections::Vec::with_capacity_in(capacity, bump) }
+    }
+
+    #[inline(always)]
+    pub(crate) fn into_inner(self) -> bumpalo::collections::Vec<'a, u8> {
+        self.inner
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+/// This implementation is taken from:
+/// https://github.com/tokio-rs/bytes/blob/4b53a29eb26716592ef2f00f925ef58ccb182e61/src/buf/buf_mut.rs#L1599
+unsafe impl BufMut for BumpBytesMut<'_> {
+    #[inline(always)]
+    fn remaining_mut(&self) -> usize {
+        isize::MAX as usize - self.inner.len()
+    }
+
+    #[inline(always)]
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        let len = self.inner.len();
+        let remaining = self.inner.capacity() - len;
+
+        if remaining < cnt {
+            panic_advance(&TryGetError { requested: cnt, available: remaining });
+        }
+
+        // SAFETY: Addition will not overflow since the sum is at most the capacity.
+        unsafe {
+            self.inner.set_len(len + cnt);
+        }
+    }
+
+    #[inline(always)]
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        if self.inner.capacity() == self.inner.len() {
+            self.inner.reserve(64); // Grow the vec
+        }
+
+        let cap = self.inner.capacity();
+        let len = self.inner.len();
+
+        let ptr = self.inner.as_mut_ptr();
+        // SAFETY: Since `ptr` is valid for `cap` bytes, `ptr.add(len)` must be
+        // valid for `cap - len` bytes. The subtraction will not underflow since
+        // `len <= cap`.
+        unsafe { UninitSlice::from_raw_parts_mut(ptr.add(len), cap - len) }
+    }
+
+    // Specialize these methods so they can skip checking `remaining_mut`
+    // and `advance_mut`.
+    #[inline]
+    fn put<T: bytes::Buf>(&mut self, mut src: T)
+    where
+        Self: Sized,
+    {
+        // In case the src isn't contiguous, reserve upfront.
+        self.inner.reserve(src.remaining());
+
+        while src.has_remaining() {
+            let s = src.chunk();
+            let l = s.len();
+            self.inner.extend_from_slice(s);
+            src.advance(l);
+        }
+    }
+
+    #[inline]
+    fn put_slice(&mut self, src: &[u8]) {
+        self.inner.extend_from_slice(src);
+    }
+
+    #[inline]
+    fn put_bytes(&mut self, val: u8, cnt: usize) {
+        // If the addition overflows, then the `resize` will fail.
+        let new_len = self.len().saturating_add(cnt);
+        self.inner.resize(new_len, val);
+    }
+}

--- a/crates/mpt/src/arena/hp.rs
+++ b/crates/mpt/src/arena/hp.rs
@@ -1,0 +1,258 @@
+//! Hex-prefix (HP) helpers and nibble utilities for MPT paths.
+use core::{cmp, iter};
+use smallvec::SmallVec;
+
+/// Compact vector for nibble sequences used in key traversal.
+pub(crate) type Nibbles = SmallVec<[u8; 64]>;
+
+// Hex-prefix (HP) encoding flags for MPT paths
+pub(crate) const HP_FLAG_ODD: u8 = 0x10; // path has odd number of nibbles; low nibble of first byte is data
+#[allow(dead_code)]
+pub(crate) const HP_FLAG_LEAF: u8 = 0x20; // node is a leaf (vs extension)
+
+/// Returns the length of the common prefix (in nibbles) between two nibble slices.
+#[inline]
+pub(crate) fn lcp(a: &[u8], b: &[u8]) -> usize {
+    for (i, (a, b)) in iter::zip(a, b).enumerate() {
+        if a != b {
+            return i;
+        }
+    }
+    cmp::min(a.len(), b.len())
+}
+
+/// Converts a byte slice into a vector of nibbles.
+/// Uses `SmallVec` to avoid heap allocation for typical key sizes (≤32 bytes = 64 nibbles).
+#[inline]
+pub(crate) fn to_nibs(slice: &[u8]) -> Nibbles {
+    let mut result = SmallVec::with_capacity(2 * slice.len());
+    for byte in slice {
+        result.push(byte >> 4);
+        result.push(byte & 0x0f);
+    }
+    result
+}
+
+/// Decodes a compact hex-prefix-encoded path (as used in MPT leaf/extension nodes)
+/// into its nibble sequence. This allocates a `SmallVec` with the exact nibble capacity.
+#[inline]
+pub(crate) fn prefix_to_nibs(encoded_path: &[u8]) -> Nibbles {
+    if encoded_path.is_empty() {
+        return SmallVec::new();
+    }
+
+    let first_byte = encoded_path[0];
+    let is_odd = (first_byte & HP_FLAG_ODD) != 0;
+    // Nibble count: if odd, first byte contains 1 nibble of data; otherwise, first byte
+    // contains only flags. Remaining bytes always contain two nibbles each.
+    let nib_count = 2 * (encoded_path.len() - 1) + if is_odd { 1 } else { 0 };
+    let mut nibs = SmallVec::with_capacity(nib_count);
+
+    // Handle the first nibble if odd length
+    if is_odd {
+        nibs.push(first_byte & 0x0f);
+    }
+
+    // Process remaining bytes, starting from index 1
+    for &byte in &encoded_path[1..] {
+        nibs.push(byte >> 4); // High nibble
+        nibs.push(byte & 0x0f); // Low nibble
+    }
+
+    nibs
+}
+
+/// Returns the number of nibbles encoded in a compact hex-prefix path.
+#[inline]
+pub(crate) fn encoded_path_nibble_count(encoded_path: &[u8]) -> usize {
+    if encoded_path.is_empty() {
+        return 0;
+    }
+    let is_odd = (encoded_path[0] & HP_FLAG_ODD) != 0;
+    2 * (encoded_path.len() - 1) + if is_odd { 1 } else { 0 }
+}
+
+/// Compares a compact hex-prefix path with a nibble slice for equality without allocating.
+#[inline]
+pub(crate) fn encoded_path_eq_nibs(encoded_path: &[u8], nibs: &[u8]) -> bool {
+    let nib_count = encoded_path_nibble_count(encoded_path);
+    if nib_count != nibs.len() {
+        return false;
+    }
+    if nib_count == 0 {
+        return true;
+    }
+
+    let first = encoded_path[0];
+    let is_odd = (first & HP_FLAG_ODD) != 0;
+    let mut i = 0usize; // index in nibs
+    let mut j = 1usize; // index in encoded_path bytes
+
+    if is_odd {
+        if nibs[i] != (first & 0x0f) {
+            return false;
+        }
+        i += 1;
+    }
+
+    while i + 1 < nibs.len() {
+        let b = encoded_path[j];
+        if nibs[i] != (b >> 4) {
+            return false;
+        }
+        if nibs[i + 1] != (b & 0x0f) {
+            return false;
+        }
+        i += 2;
+        j += 1;
+    }
+
+    if i < nibs.len() {
+        // one last high nibble remains
+        let b = encoded_path[j];
+        if nibs[i] != (b >> 4) {
+            return false;
+        }
+    }
+    true
+}
+
+/// If `encoded_path` is a prefix of `nibs`, returns the tail `&nibs[matched_len..]`.
+#[inline]
+pub(crate) fn encoded_path_strip_prefix<'a>(
+    encoded_path: &[u8],
+    nibs: &'a [u8],
+) -> Option<&'a [u8]> {
+    let nib_count = encoded_path_nibble_count(encoded_path);
+    if nib_count > nibs.len() {
+        return None;
+    }
+    if nib_count == 0 {
+        return Some(nibs);
+    }
+
+    let first = encoded_path[0];
+    let is_odd = (first & HP_FLAG_ODD) != 0;
+    let mut i = 0usize; // index in nibs
+    let mut j = 1usize; // index in encoded_path bytes
+
+    if is_odd {
+        if nibs[i] != (first & 0x0f) {
+            return None;
+        }
+        i += 1;
+    }
+
+    while i + 1 < nib_count {
+        let b = encoded_path[j];
+        if nibs[i] != (b >> 4) {
+            return None;
+        }
+        if nibs[i + 1] != (b & 0x0f) {
+            return None;
+        }
+        i += 2;
+        j += 1;
+    }
+
+    if i < nib_count {
+        let b = encoded_path[j];
+        if nibs[i] != (b >> 4) {
+            return None;
+        }
+        i += 1;
+    }
+    Some(&nibs[i..])
+}
+
+/// Encodes nibbles into the standard hex-prefix format directly into the bump arena.
+#[inline]
+pub(crate) fn to_encoded_path_with_bump<'a>(
+    bump: &'a bumpalo::Bump,
+    nibs: &[u8],
+    is_leaf: bool,
+) -> &'a [u8] {
+    let is_odd = !nibs.len().is_multiple_of(2);
+    let encoded_len = 1 + (nibs.len() / 2);
+    let mut encoded = bumpalo::collections::Vec::with_capacity_in(encoded_len, bump);
+
+    let mut prefix = if is_leaf { 0x20 } else { 0x00 };
+    if is_odd {
+        prefix |= 0x10;
+        encoded.push(prefix | nibs[0]);
+        for i in (1..nibs.len()).step_by(2) {
+            encoded.push((nibs[i] << 4) | nibs[i + 1]);
+        }
+    } else {
+        encoded.push(prefix);
+        for i in (0..nibs.len()).step_by(2) {
+            encoded.push((nibs[i] << 4) | nibs[i + 1]);
+        }
+    }
+
+    encoded.into_bump_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encoded_path_nibble_count() {
+        assert_eq!(encoded_path_nibble_count(&[]), 0);
+        // ODD+LEAF with one nibble 0xA
+        assert_eq!(encoded_path_nibble_count(&[HP_FLAG_ODD | HP_FLAG_LEAF | 0x0a]), 1);
+        // EVEN+EXT with 2 bytes => 4 nibbles
+        assert_eq!(encoded_path_nibble_count(&[0x00, 0xab, 0xcd]), 4);
+    }
+
+    #[test]
+    fn test_eq_and_strip_prefix() {
+        // path [1, 2, 3] as HP: ODD + EXT, first byte 0x10 | 0x1, then 0x23
+        let path = [HP_FLAG_ODD | 0x01, 0x23];
+        let key = [1, 2, 3];
+        assert!(encoded_path_eq_nibs(&path, &key));
+        assert_eq!(encoded_path_strip_prefix(&path, &key), Some(&[][..]));
+
+        let key_longer = [1, 2, 3, 4, 5];
+        assert_eq!(encoded_path_strip_prefix(&path, &key_longer), Some(&key_longer[3..]));
+
+        let key_mismatch = [1, 2, 4];
+        assert!(encoded_path_strip_prefix(&path, &key_mismatch).is_none());
+    }
+
+    #[test]
+    fn test_to_encoded_path() {
+        let bump = bumpalo::Bump::new();
+
+        // extension node with an even path length
+        let nibbles = vec![0x0a, 0x0b, 0x0c, 0x0d];
+        assert_eq!(to_encoded_path_with_bump(&bump, &nibbles, false), vec![0x00, 0xab, 0xcd]);
+        // extension node with an odd path length
+        let nibbles = vec![0x0a, 0x0b, 0x0c];
+        assert_eq!(to_encoded_path_with_bump(&bump, &nibbles, false), vec![0x1a, 0xbc]);
+        // leaf node with an even path length
+        let nibbles = vec![0x0a, 0x0b, 0x0c, 0x0d];
+        assert_eq!(to_encoded_path_with_bump(&bump, &nibbles, true), vec![0x20, 0xab, 0xcd]);
+        // leaf node with an odd path length
+        let nibbles = vec![0x0a, 0x0b, 0x0c];
+        assert_eq!(to_encoded_path_with_bump(&bump, &nibbles, true), vec![0x3a, 0xbc]);
+    }
+
+    #[test]
+    fn test_lcp() {
+        let cases = [
+            (vec![], vec![], 0),
+            (vec![0xa], vec![0xa], 1),
+            (vec![0xa, 0xb], vec![0xa, 0xc], 1),
+            (vec![0xa, 0xb], vec![0xa, 0xb], 2),
+            (vec![0xa, 0xb], vec![0xa, 0xb, 0xc], 2),
+            (vec![0xa, 0xb, 0xc], vec![0xa, 0xb, 0xc], 3),
+            (vec![0xa, 0xb, 0xc], vec![0xa, 0xb, 0xc, 0xd], 3),
+            (vec![0xa, 0xb, 0xc, 0xd], vec![0xa, 0xb, 0xc, 0xd], 4),
+        ];
+        for (a, b, cpl) in cases {
+            assert_eq!(lcp(&a, &b), cpl)
+        }
+    }
+}

--- a/crates/mpt/src/arena/mod.rs
+++ b/crates/mpt/src/arena/mod.rs
@@ -1,0 +1,23 @@
+//! Experimental arena-based, zero-copy Merkle Patricia Trie.
+//!
+//! Ported from the `openvm-eth` fork of RSP. Compared to the legacy pointer-based `MptNode`
+//! (`crate::mpt`), this implementation:
+//!
+//! * stores every node in a flat `Vec`, referencing children by `u32` index (cache-friendly, no
+//!   per-node `Box` allocation);
+//! * borrows leaf/extension paths and values directly from the input buffer or a `bumpalo` bump
+//!   arena (zero-copy), instead of owning heap `Vec`s;
+//! * caches node references with `Cell` instead of a per-node `Mutex`;
+//! * traverses keys without ever materializing a `Vec<u8>` of nibbles.
+//!
+//! These properties matter inside a zkVM, where heap allocation is proven cycle-for-cycle.
+
+mod trie;
+pub use trie::*;
+
+mod bump_bufmut;
+mod hp;
+mod node;
+
+#[cfg(test)]
+mod tests;

--- a/crates/mpt/src/arena/node.rs
+++ b/crates/mpt/src/arena/node.rs
@@ -1,0 +1,75 @@
+use alloy_primitives::hex;
+
+pub(crate) type NodeId = u32;
+
+/// Node data for arena-based trie with zero-copy optimization
+#[derive(Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd)]
+pub(crate) enum NodeData<'a> {
+    #[default]
+    /// Absence of a node. Encoded as empty string in RLP.
+    Null,
+    /// 16-way branch. Each child is optional; the branch's value slot is unused in our state trie
+    /// and must be empty, enforced during decoding.
+    Branch([Option<NodeId>; 16]),
+    /// Leaf node containing a compact hex-prefix path and a value. Both slices borrow from the
+    /// input buffer or bump arena. The path encodes the remainder of the key.
+    Leaf(&'a [u8], &'a [u8]),
+    /// Extension node containing a compact hex-prefix path and a single child. Path encodes a
+    /// shared prefix to skip before continuing at `child`.
+    Extension(&'a [u8], NodeId),
+    /// Unresolved reference to a node by its Keccak-256 digest (32 bytes). Encountering this in
+    /// `get`/`insert`/`delete` is an error; resolution happens in `build_mpt` helpers.
+    Digest(&'a [u8]),
+}
+
+/// Represents the ways in which one node can reference another node inside the sparse Merkle
+/// Patricia Trie (MPT).
+///
+/// Nodes in the MPT can reference other nodes either directly through their byte representation or
+/// indirectly through a hash of their encoding.
+#[derive(Copy, Clone, Debug, Hash)]
+pub(crate) enum NodeRef<'a> {
+    /// Represents a direct reference to another node using its byte encoding. Typically
+    /// used for short encodings that are less than 32 bytes in length.
+    Bytes(&'a [u8]),
+    /// Represents an indirect reference to another node using the Keccak hash of its long
+    /// encoding, so its length is always 32. Used for encodings that are not less than 32 bytes in
+    /// length.
+    Digest(&'a [u8]),
+}
+
+impl std::fmt::Display for NodeRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeRef::Bytes(bytes) => write!(f, "Bytes(0x{})", hex::encode(bytes)),
+            NodeRef::Digest(digest) => write!(f, "Digest(0x{})", hex::encode(digest)),
+        }
+    }
+}
+
+impl PartialEq for NodeRef<'_> {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<'a> NodeRef<'a> {
+    #[inline(always)]
+    pub(crate) fn as_slice(&self) -> &'a [u8] {
+        match self {
+            NodeRef::Bytes(slice) => slice,
+            NodeRef::Digest(slice) => slice,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn from_rlp_slice(slice: &'a [u8]) -> Self {
+        if slice.len() == 33 {
+            Self::Digest(&slice[1..])
+        } else {
+            debug_assert!(slice.len() < 32);
+            Self::Bytes(slice)
+        }
+    }
+}

--- a/crates/mpt/src/arena/tests.rs
+++ b/crates/mpt/src/arena/tests.rs
@@ -1,0 +1,244 @@
+use alloy_primitives::{b256, keccak256, B256};
+
+use super::{node::NodeData, Error, Mpt};
+
+/// The legacy `MptNode` and the arena `Mpt` must agree on the root hash after a structural
+/// conversion, and the encode -> decode round-trip (the host->guest witness path) must preserve
+/// it. This is the correctness foundation for the arena witness integration.
+#[test]
+fn test_from_mpt_node_roundtrip() {
+    use bumpalo::Bump;
+
+    use crate::mpt::MptNode;
+
+    let mut legacy = MptNode::default();
+    for i in 0..2000u64 {
+        legacy.insert_rlp(keccak256(i.to_be_bytes()).as_slice(), i).unwrap();
+    }
+    let legacy_root = legacy.hash();
+
+    // Structural conversion must reproduce the exact root.
+    let bump = Bump::new();
+    let arena = Mpt::from_mpt_node(&bump, &legacy);
+    assert_eq!(arena.hash(), legacy_root, "arena conversion root mismatch");
+
+    // encode_trie (host) -> decode_trie (guest, zero-copy + hash-verifying) must round-trip.
+    let encoded = arena.encode_trie();
+    let num_nodes = arena.num_nodes();
+    let decode_bump = Bump::new();
+    let mut slice = encoded.as_slice();
+    let decoded = Mpt::decode_trie(&decode_bump, &mut slice, num_nodes).unwrap();
+    assert_eq!(decoded.hash(), legacy_root, "decoded arena root mismatch");
+}
+
+trait RlpBytes {
+    /// Returns the RLP-encoding.
+    fn to_rlp(&self) -> Vec<u8>;
+}
+
+impl<T> RlpBytes for T
+where
+    T: alloy_rlp::Encodable,
+{
+    #[inline]
+    fn to_rlp(&self) -> Vec<u8> {
+        let rlp_length = self.length();
+        let mut out = Vec::with_capacity(rlp_length);
+        self.encode(&mut out);
+        debug_assert_eq!(out.len(), rlp_length);
+        out
+    }
+}
+
+#[test]
+fn test_empty() {
+    let bump = bumpalo::Bump::new();
+    let trie = Mpt::new(&bump);
+
+    assert!(trie.is_empty());
+    let expected = b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    assert_eq!(expected, trie.hash());
+}
+
+#[test]
+fn test_empty_key() -> Result<(), Error> {
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+
+    trie.insert(&[], b"empty")?;
+    assert_eq!(trie.get(&[])?, Some(b"empty".as_ref()));
+    assert!(trie.delete(&[])?);
+
+    Ok(())
+}
+
+#[test]
+fn test_branch_value() {
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+    trie.insert(b"do", b"verb").unwrap();
+    // leads to a branch with value which is not supported
+    trie.insert(b"dog", b"puppy").unwrap_err();
+}
+
+#[test]
+fn test_insert() -> Result<(), Error> {
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+
+    let key_vals = vec![
+        ("painting", "place"),
+        ("guest", "ship"),
+        ("mud", "leave"),
+        ("paper", "call"),
+        ("gate", "boast"),
+        ("tongue", "gain"),
+        ("baseball", "wait"),
+        ("tale", "lie"),
+        ("mood", "cope"),
+        ("menu", "fear"),
+    ];
+    for (key, val) in &key_vals {
+        assert!(trie.insert(key.as_bytes(), val.as_bytes())?);
+    }
+
+    // Identical root hash to the legacy `MptNode` implementation's `test_insert`.
+    let expected = b256!("2bab6cdf91a23ebf3af683728ea02403a98346f99ed668eec572d55c70a4b08f");
+    assert_eq!(expected, trie.hash());
+
+    for (key, value) in &key_vals {
+        let retrieved = trie.get(key.as_bytes())?.unwrap();
+        assert_eq!(retrieved, value.as_bytes());
+    }
+
+    // check inserting duplicate keys
+    assert!(trie.insert(key_vals[0].0.as_bytes(), b"new")?);
+    assert!(!trie.insert(key_vals[0].0.as_bytes(), b"new")?);
+
+    Ok(())
+}
+
+#[test]
+fn test_keccak_trie() -> Result<(), Error> {
+    const N: usize = 512;
+
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+
+    for i in 0..N {
+        assert!(trie.insert_rlp(keccak256(i.to_be_bytes()).as_slice(), i)?);
+
+        // check hash against trie built in reverse
+        let bump2 = bumpalo::Bump::new();
+        let mut trie2 = Mpt::new(&bump2);
+        for j in (0..=i).rev() {
+            trie2.insert_rlp(keccak256(j.to_be_bytes()).as_slice(), j)?;
+        }
+        assert_eq!(trie.hash(), trie2.hash());
+    }
+
+    // Identical root hash to the legacy `MptNode` implementation's `test_keccak_trie`.
+    let expected = b256!("7310027edebdd1f7c950a7fb3413d551e85dff150d45aca4198c2f6315f9b4a7");
+    assert_eq!(trie.hash(), expected);
+
+    for i in 0..N {
+        assert_eq!(trie.get_rlp(keccak256(i.to_be_bytes()).as_slice())?, Some(i));
+        assert!(trie.get(keccak256((i + N).to_be_bytes()).as_slice())?.is_none());
+    }
+
+    for i in 0..N {
+        assert!(trie.delete(keccak256(i.to_be_bytes()).as_slice())?);
+
+        let bump2 = bumpalo::Bump::new();
+        let mut trie2 = Mpt::new(&bump2);
+        for j in ((i + 1)..N).rev() {
+            trie2.insert_rlp(keccak256(j.to_be_bytes()).as_slice(), j)?;
+        }
+        assert_eq!(trie.hash(), trie2.hash());
+    }
+    assert!(trie.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_index_trie() -> Result<(), Error> {
+    const N: usize = 512;
+
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+
+    for i in 0..N {
+        assert!(trie.insert_rlp(&i.to_rlp(), i)?);
+    }
+
+    for i in 0..N {
+        assert_eq!(trie.get_rlp(&i.to_rlp())?, Some(i));
+        assert!(trie.get(&(i + N).to_rlp())?.is_none());
+    }
+
+    for i in 0..N {
+        assert!(trie.delete(&i.to_rlp()).unwrap());
+    }
+    assert!(trie.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_encode_decode_roundtrip() -> Result<(), Error> {
+    const N: usize = 512;
+
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+
+    for i in 0..N {
+        assert!(trie.insert_rlp(keccak256(i.to_be_bytes()).as_slice(), i)?);
+    }
+
+    let root_hash = trie.hash();
+    let encoded = trie.encode_trie();
+
+    let bump2 = bumpalo::Bump::new();
+    let recovered = Mpt::decode_trie(&bump2, &mut encoded.as_slice(), trie.num_nodes())?;
+    assert_eq!(recovered.hash(), root_hash);
+
+    for i in 0..N {
+        assert_eq!(recovered.get_rlp(keccak256(i.to_be_bytes()).as_slice())?, Some(i));
+    }
+
+    Ok(())
+}
+
+/// A `delete` that collapses a branch onto an unresolved `Digest` sibling must error rather
+/// than silently producing a wrong root. (Contrast with the legacy `MptNode`, which wraps the
+/// digest in an `Extension`.)
+#[test]
+fn test_delete_with_unresolved_sibling_errors() {
+    use super::hp::to_encoded_path_with_bump;
+
+    let bump = bumpalo::Bump::new();
+    let mut trie = Mpt::new(&bump);
+
+    let fake_digest: &[u8] = bump.alloc_slice_copy(&[0xABu8; 32]);
+
+    let leaf_path = to_encoded_path_with_bump(&bump, &[0], true);
+    let leaf_id = trie.add_node(NodeData::Leaf(leaf_path, b"value"), None);
+
+    let digest_id = trie.add_node(NodeData::Digest(fake_digest), None);
+
+    let mut children: [Option<u32>; 16] = Default::default();
+    children[0] = Some(leaf_id);
+    children[1] = Some(digest_id);
+    let branch_id = trie.add_node(NodeData::Branch(children), None);
+
+    trie.set_root_id(branch_id);
+
+    match trie.delete(&[0x00]) {
+        Err(Error::NodeNotResolved(hash)) => {
+            assert_eq!(hash, B256::from_slice(fake_digest));
+        }
+        Ok(_) => panic!("Expected NodeNotResolved error, but delete succeeded"),
+        Err(e) => panic!("Expected NodeNotResolved error, got: {e:?}"),
+    }
+}

--- a/crates/mpt/src/arena/trie.rs
+++ b/crates/mpt/src/arena/trie.rs
@@ -1,0 +1,952 @@
+use std::{
+    cell::{Cell, RefCell},
+    mem::MaybeUninit,
+};
+
+use alloy_primitives::{b256, hex, keccak256, B256};
+use alloy_rlp::Encodable;
+use bumpalo::Bump;
+use bytes::Buf;
+use smallvec::SmallVec;
+
+use super::{
+    bump_bufmut::BumpBytesMut,
+    hp::{
+        encoded_path_eq_nibs, encoded_path_strip_prefix, lcp, prefix_to_nibs,
+        to_encoded_path_with_bump, to_nibs,
+    },
+    node::{NodeData, NodeId, NodeRef},
+};
+
+/// OpenVM memory alignment word size.
+const MIN_ALIGN: usize = 4;
+
+/// Initial capacity of [`Mpt`]'s `rlp_scratch`.
+const RLP_SCRATCH_INIT_CAPACITY: usize = 600;
+
+const VALUE_RLP_BUFFER_CAPACITY: usize = 200;
+
+/// Root hash of an empty trie.
+pub const EMPTY_ROOT: B256 =
+    b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+
+/// Sentinel index representing the null node when decoding and in internal references.
+/// In a default MPT, `nodes[0]` starts as `Null`, but the root may later be changed to a
+/// non-null node (e.g. `Digest`) for convenience. `NULL_NODE_ID` is still used by the decoder
+/// as the canonical "no node" identifier.
+pub(crate) const NULL_NODE_ID: NodeId = 0;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Node reference does not match the expected node reference in the parent.
+    #[error("node reference mismatch")]
+    NodeRefMismatch,
+    /// Triggered when an operation reaches an unresolved node. The associated `B256`
+    /// value provides details about the unresolved node.
+    #[error("reached an unresolved node: {0:#}")]
+    NodeNotResolved(B256),
+    /// Represents errors related to the RLP encoding and decoding.
+    #[error("rlp decode error: {0}")]
+    RlpError(#[from] alloy_rlp::Error),
+    /// Occurs when a value is unexpectedly found in a branch node.
+    #[error("branch node with value")]
+    ValueInBranch,
+}
+
+/// Arena-based implementation that stores all nodes in a flat vector and uses indices for better
+/// memory layout and performance. The lifetime parameter `'a` allows zero-copy deserialization by
+/// borrowing from the input buffer.
+#[derive(Debug, Clone)]
+pub struct Mpt<'a> {
+    root_id: NodeId,
+
+    /// List of MPT nodes.
+    nodes: Vec<NodeData<'a>>,
+
+    /// Cache. Hashing/encoding often needs "what would this node look like in its parent"
+    cached_references: Vec<Cell<Option<NodeRef<'a>>>>,
+
+    /// Scratch buffer used only for RLP encoding when a node's full RLP exceeds 32 bytes and we
+    /// need to compute its keccak hash. Keeping it here avoids repeated allocations.
+    rlp_scratch: RefCell<Vec<u8>>,
+
+    /// Bump allocation area.
+    bump: &'a Bump,
+}
+
+impl<'a> Mpt<'a> {
+    pub fn new(bump: &'a Bump) -> Self {
+        Self::with_capacity(bump, 1)
+    }
+
+    pub fn num_nodes(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn with_capacity(bump: &'a Bump, capacity: usize) -> Self {
+        let mut nodes = Vec::with_capacity(capacity);
+        let mut cached_references = Vec::with_capacity(capacity);
+        nodes.push(NodeData::Null);
+        cached_references.push(Cell::new(None));
+
+        Self {
+            nodes,
+            rlp_scratch: RefCell::new(Vec::with_capacity(RLP_SCRATCH_INIT_CAPACITY)),
+            cached_references,
+            bump,
+            root_id: 0,
+        }
+    }
+
+    /// Builds an arena trie from a legacy pointer-based [`MptNode`] (host-side construction).
+    ///
+    /// The two representations map 1:1 — leaf/extension paths and values are the same
+    /// hp-encoded byte slices — so this is a faithful structural copy that preserves unresolved
+    /// `Digest` nodes (unlike re-inserting leaves, which would drop the sparse digests of a
+    /// witness trie). Paths and values are copied into the bump arena. Pair with
+    /// [`Mpt::encode_trie`] to produce the bytes the guest decodes zero-copy via
+    /// [`Mpt::decode_trie`].
+    pub fn from_mpt_node(bump: &'a Bump, node: &crate::mpt::MptNode) -> Self {
+        let mut trie = Self::new(bump);
+        trie.root_id = trie.add_mpt_node(node);
+        trie
+    }
+
+    fn add_mpt_node(&mut self, node: &crate::mpt::MptNode) -> NodeId {
+        use crate::mpt::MptNodeData;
+        let data = match node.as_data() {
+            MptNodeData::Null => NodeData::Null,
+            MptNodeData::Leaf(prefix, value) => {
+                let prefix = self.bump.alloc_slice_copy(prefix.as_slice());
+                let value = self.bump.alloc_slice_copy(value.as_slice());
+                NodeData::Leaf(prefix, value)
+            }
+            MptNodeData::Extension(prefix, child) => {
+                let child_id = self.add_mpt_node(child);
+                let prefix = self.bump.alloc_slice_copy(prefix.as_slice());
+                NodeData::Extension(prefix, child_id)
+            }
+            MptNodeData::Branch(children) => {
+                let mut ids: [Option<NodeId>; 16] = [None; 16];
+                for (i, child) in children.iter().enumerate() {
+                    if let Some(child) = child {
+                        ids[i] = Some(self.add_mpt_node(child));
+                    }
+                }
+                NodeData::Branch(ids)
+            }
+            MptNodeData::Digest(digest) => {
+                let digest = self.bump.alloc_slice_copy(digest.as_slice());
+                NodeData::Digest(digest)
+            }
+        };
+        self.add_node(data, None)
+    }
+}
+
+/// Same as `let (bytes, rest) = buf.split_at(cnt); *buf = rest; bytes`.
+#[inline(always)]
+unsafe fn advance_unchecked<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
+    let bytes = &buf[..cnt];
+    buf.advance(cnt);
+    bytes
+}
+
+impl<'a> Mpt<'a> {
+    /// Encodes the MPT into an array of bytes. This is only used in the host, as a result it's not
+    /// performance-critical.
+    pub fn encode_trie(&self) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        self.encode_trie_internal(self.root_id, &mut encoded);
+        encoded
+    }
+
+    fn encode_trie_internal(&self, node_id: NodeId, out: &mut dyn alloy_rlp::BufMut) {
+        let payload_length = self.payload_length(node_id);
+        self.encode_with_payload_len(node_id, payload_length, out);
+
+        // Pad the RLP encoding so its total length is divisible by `MIN_ALIGN`.
+        // This let us to avoid memcpy operations when calculating keccak(rlp_encoded) during
+        // decoding.
+        let rlp_length = payload_length + alloy_rlp::length_of_length(payload_length);
+        let padding_len = (MIN_ALIGN - (rlp_length % MIN_ALIGN)) % MIN_ALIGN;
+        for _ in 0..padding_len {
+            out.put_u8(0);
+        }
+
+        match self.nodes[node_id as usize] {
+            NodeData::Branch(childs) => {
+                childs.iter().for_each(|c| {
+                    if let Some(child_id) = c {
+                        self.encode_trie_internal(*child_id, out)
+                    }
+                });
+            }
+            NodeData::Extension(_, ext_id) => {
+                self.encode_trie_internal(ext_id, out);
+            }
+            _ => {}
+        }
+    }
+
+    /// Decodes the given `bytes` into and creates an `Mpt`.
+    pub fn decode_trie(
+        bump: &'a Bump,
+        bytes: &mut &'a [u8],
+        num_nodes: usize,
+    ) -> Result<Self, Error> {
+        if bytes == &[alloy_rlp::EMPTY_STRING_CODE, 0, 0, 0] {
+            return Ok(Self::new(bump));
+        }
+
+        // A growth factor applied to the node vector's capacity during deserialization.
+        // This is a pragmatic optimization to pre-allocate a buffer for nodes that will be
+        // added during the `update` phase. It prevents a "reallocation storm" where the
+        // main trie and dozens of storage tries all try to reallocate their full node
+        // vectors on the first update.
+        let capacity = num_nodes + (num_nodes / 2);
+        let mut trie = Self::with_capacity(bump, capacity);
+
+        // construct the expected root reference
+        let root_ref = {
+            let mut buf = *bytes;
+            let rlp_node_header_start = buf;
+            let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(&mut buf)?;
+            // SAFETY: we already decoded the header, so we know the payload length.
+            let payload = unsafe { advance_unchecked(&mut buf, payload_length) };
+            let rlp_node_length = rlp_node_header_start.len() - buf.len();
+
+            let rlp_node = &rlp_node_header_start[..rlp_node_length];
+            if rlp_node.len() < 32 {
+                NodeRef::Bytes(rlp_node)
+            } else if !list {
+                NodeRef::Digest(payload)
+            } else {
+                let digest = keccak256(rlp_node);
+                let digest_slice = bump.alloc_slice_copy(digest.as_slice());
+                NodeRef::Digest(digest_slice)
+            }
+        };
+
+        let root_id = trie.decode_trie_internal(bytes, root_ref)?;
+        trie.root_id = root_id;
+
+        Ok(trie)
+    }
+
+    fn decode_trie_internal(
+        &mut self,
+        bytes: &mut &'a [u8],
+        expected_node_ref: NodeRef<'a>,
+    ) -> Result<NodeId, Error> {
+        let rlp_node_header_start = *bytes;
+        let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(bytes)?;
+
+        // SAFETY: we already decoded the header, so we know the payload length.
+        let mut payload = unsafe { advance_unchecked(bytes, payload_length) };
+        let rlp_node_length = rlp_node_header_start.len() - bytes.len();
+
+        let rlp_node = &rlp_node_header_start[..rlp_node_length];
+
+        let padding_len = (MIN_ALIGN - (rlp_node_length % MIN_ALIGN)) % MIN_ALIGN;
+        // SAFETY: we expect the padding. See the `encode_trie_internal` function.
+        unsafe { advance_unchecked(bytes, padding_len) };
+
+        // calculate node's reference and ensure it matches the `expected_node_ref` from parent.
+        let node_ref = {
+            if rlp_node_length < 32 {
+                if rlp_node != expected_node_ref.as_slice() {
+                    return Err(Error::NodeRefMismatch);
+                }
+                NodeRef::Bytes(rlp_node)
+            } else if payload_length == 32 && !list {
+                if payload != expected_node_ref.as_slice() {
+                    return Err(Error::NodeRefMismatch);
+                }
+                expected_node_ref
+            } else {
+                let digest = keccak256(rlp_node);
+                if digest != expected_node_ref.as_slice() {
+                    return Err(Error::NodeRefMismatch);
+                }
+                expected_node_ref
+            }
+        };
+
+        if !list {
+            let node_id = match payload_length {
+                0 => NULL_NODE_ID,
+                32 => self.add_node(NodeData::Digest(payload), Some(NodeRef::Digest(payload))),
+                _ => {
+                    return Err(Error::RlpError(alloy_rlp::Error::UnexpectedLength));
+                }
+            };
+            return Ok(node_id);
+        }
+
+        // first payload item
+        let item0_header_start = payload;
+        let alloy_rlp::Header { payload_length: item0_payload_length, .. } =
+            alloy_rlp::Header::decode(&mut payload)?;
+        // SAFETY: we already decoded the header, so we know the payload length.
+        let item0_payload_start = unsafe { advance_unchecked(&mut payload, item0_payload_length) };
+        let item0_length = item0_header_start.len() - payload.len();
+
+        // second payload item
+        let item1_header_start = payload;
+        let alloy_rlp::Header { payload_length: item1_payload_length, .. } =
+            alloy_rlp::Header::decode(&mut payload)?;
+        // SAFETY: we already decoded the header, so we know the payload length.
+        let item1_payload_start = unsafe { advance_unchecked(&mut payload, item1_payload_length) };
+        let item1_length = item1_header_start.len() - payload.len();
+
+        if payload.is_empty() {
+            // either an extension or leaf
+            let path = &item0_payload_start[..item0_payload_length];
+            let prefix = path[0];
+            if (prefix & (2 << 4)) == 0 {
+                // extension node
+                let ext_node_expected_ref =
+                    NodeRef::from_rlp_slice(&item1_header_start[..item1_length]);
+                let ext_node_id = self.decode_trie_internal(bytes, ext_node_expected_ref)?;
+                let node_data = NodeData::Extension(path, ext_node_id);
+                return Ok(self.add_node(node_data, Some(node_ref)));
+            } else {
+                // leaf node
+                let value = &item1_payload_start[..item1_payload_length];
+                let node_data = NodeData::Leaf(path, value);
+                return Ok(self.add_node(node_data, Some(node_ref)));
+            }
+        }
+
+        // branch
+        let child0_expected_node_ref = NodeRef::from_rlp_slice(&item0_header_start[..item0_length]);
+        let child0 = {
+            if child0_expected_node_ref.as_slice() == NULL_NODE_REF_SLICE {
+                None
+            } else {
+                Some(self.decode_trie_internal(bytes, child0_expected_node_ref)?)
+            }
+        };
+
+        let child1_expected_node_ref = NodeRef::from_rlp_slice(&item1_header_start[..item1_length]);
+        let child1 = {
+            if child1_expected_node_ref.as_slice() == NULL_NODE_REF_SLICE {
+                None
+            } else {
+                Some(self.decode_trie_internal(bytes, child1_expected_node_ref)?)
+            }
+        };
+
+        // Create an uninitialized array to avoid wasteful default initialization
+        // SAFETY: below we assign to each element of the array.
+        let mut childs: [MaybeUninit<Option<NodeId>>; 16] =
+            unsafe { MaybeUninit::uninit().assume_init() };
+
+        // Initialize first two elements
+        childs[0] = MaybeUninit::new(child0);
+        childs[1] = MaybeUninit::new(child1);
+
+        // Initialize remaining elements
+        for child in &mut childs[2..] {
+            let item_header_start = payload;
+            let alloy_rlp::Header { payload_length: item_payload_length, .. } =
+                alloy_rlp::Header::decode(&mut payload)?;
+            // SAFETY: we already decoded the header, so we know the payload length.
+            unsafe { advance_unchecked(&mut payload, item_payload_length) };
+            let item_length = item_header_start.len() - payload.len();
+
+            let child_expected_node_ref =
+                NodeRef::from_rlp_slice(&item_header_start[..item_length]);
+
+            *child = MaybeUninit::new({
+                if child_expected_node_ref.as_slice() == NULL_NODE_REF_SLICE {
+                    None
+                } else {
+                    Some(self.decode_trie_internal(bytes, child_expected_node_ref)?)
+                }
+            });
+        }
+
+        // Transmute the fully initialized array to the final type
+        // SAFETY: we already initialized all elements of the array.
+        let childs: [Option<NodeId>; 16] = unsafe {
+            std::mem::transmute::<[MaybeUninit<Option<NodeId>>; 16], [Option<NodeId>; 16]>(childs)
+        };
+
+        if payload != NULL_NODE_REF_SLICE {
+            return Err(Error::ValueInBranch);
+        }
+
+        let node_data = NodeData::Branch(childs);
+        let node_id = self.add_node(node_data, Some(node_ref));
+        Ok(node_id)
+    }
+}
+
+pub(crate) const NULL_NODE_REF_SLICE: &[u8] = &[alloy_rlp::EMPTY_STRING_CODE];
+
+impl<'a> Mpt<'a> {
+    #[inline]
+    fn calc_reference(&self, node_id: NodeId) -> NodeRef<'a> {
+        match &self.nodes[node_id as usize] {
+            NodeData::Null => NodeRef::Bytes(NULL_NODE_REF_SLICE),
+            NodeData::Digest(digest) => NodeRef::Digest(digest),
+            _ => {
+                let payload_length = self.payload_length(node_id);
+                let rlp_length = payload_length + alloy_rlp::length_of_length(payload_length);
+
+                if rlp_length < 32 {
+                    let mut encoded = BumpBytesMut::with_capacity_in(rlp_length, self.bump);
+                    self.encode_with_payload_len(node_id, payload_length, &mut encoded);
+                    debug_assert_eq!(encoded.len(), rlp_length);
+
+                    NodeRef::Bytes(encoded.into_inner().into_bump_slice())
+                } else {
+                    let mut scratch = self.rlp_scratch.borrow_mut();
+                    scratch.clear();
+
+                    self.encode_with_payload_len(node_id, payload_length, &mut *scratch);
+                    debug_assert_eq!(scratch.len(), rlp_length);
+
+                    let digest = keccak256(&*scratch);
+                    let digest_slice = self.bump.alloc_slice_copy(digest.as_slice());
+                    NodeRef::Digest(digest_slice)
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn encode_with_payload_len(
+        &self,
+        node_id: NodeId,
+        payload_length: usize,
+        out: &mut dyn alloy_rlp::BufMut,
+    ) {
+        match &self.nodes[node_id as usize] {
+            NodeData::Null => {
+                out.put_u8(alloy_rlp::EMPTY_STRING_CODE);
+            }
+            NodeData::Branch(nodes) => {
+                alloy_rlp::Header { list: true, payload_length }.encode(out);
+                for child_id in nodes.iter() {
+                    match child_id {
+                        Some(id) => self.reference_encode(*id, out),
+                        None => out.put_u8(alloy_rlp::EMPTY_STRING_CODE),
+                    }
+                }
+                // in the MPT reference, branches have values so always add empty value
+                out.put_u8(alloy_rlp::EMPTY_STRING_CODE);
+            }
+            NodeData::Leaf(encoded_path, value) => {
+                alloy_rlp::Header { list: true, payload_length }.encode(out);
+                encoded_path.encode(out);
+                value.encode(out);
+            }
+            NodeData::Extension(encoded_path, child_id) => {
+                alloy_rlp::Header { list: true, payload_length }.encode(out);
+                encoded_path.encode(out);
+                self.reference_encode(*child_id, out);
+            }
+            NodeData::Digest(digest) => {
+                digest.encode(out);
+            }
+        }
+    }
+
+    #[inline]
+    fn reference_encode(&self, node_id: NodeId, out: &mut dyn alloy_rlp::BufMut) {
+        let cached = self.cached_references[node_id as usize].get();
+        let node_ref = match cached {
+            Some(node_ref) => node_ref,
+            None => {
+                let node_ref = self.calc_reference(node_id);
+                self.cached_references[node_id as usize].set(Some(node_ref));
+                node_ref
+            }
+        };
+        match node_ref {
+            // if the reference is an RLP-encoded byte slice, copy it directly
+            NodeRef::Bytes(bytes) => out.put_slice(bytes),
+            // if the reference is a digest, RLP-encode it with its fixed known length
+            NodeRef::Digest(digest) => {
+                out.put_u8(alloy_rlp::EMPTY_STRING_CODE + 32);
+                out.put_slice(digest);
+            }
+        }
+    }
+
+    /// Returns the length of the RLP payload of the node.
+    #[inline]
+    fn payload_length(&self, node_id: NodeId) -> usize {
+        match &self.nodes[node_id as usize] {
+            NodeData::Null => 0,
+            NodeData::Branch(nodes) => {
+                1 + nodes
+                    .iter()
+                    .map(|child| child.map_or(1, |id| self.reference_length(id)))
+                    .sum::<usize>()
+            }
+            NodeData::Leaf(encoded_path, value) => encoded_path.length() + value.length(),
+            NodeData::Extension(encoded_path, node_id) => {
+                encoded_path.length() + self.reference_length(*node_id)
+            }
+            NodeData::Digest(_) => 32,
+        }
+    }
+
+    /// Returns the length of the encoded [NodeRef] of this node.
+    #[inline]
+    fn reference_length(&self, node_id: NodeId) -> usize {
+        let cached = self.cached_references[node_id as usize].get();
+        let node_ref = match cached {
+            Some(node_ref) => node_ref,
+            None => {
+                let node_ref = self.calc_reference(node_id);
+                self.cached_references[node_id as usize].set(Some(node_ref));
+                node_ref
+            }
+        };
+        match node_ref {
+            NodeRef::Bytes(bytes) => bytes.len(),
+            NodeRef::Digest(_) => 1 + 32,
+        }
+    }
+}
+
+// Public API
+impl<'a> Mpt<'a> {
+    /// Root hash of the MPT.
+    #[inline]
+    pub fn hash(&self) -> B256 {
+        match self.nodes[self.root_id as usize] {
+            NodeData::Null => EMPTY_ROOT,
+            _ => {
+                let cached = self.cached_references[self.root_id as usize].get();
+                let node_ref = match cached {
+                    Some(node_ref) => node_ref,
+                    None => {
+                        let node_ref = self.calc_reference(self.root_id);
+                        self.cached_references[self.root_id as usize].set(Some(node_ref));
+                        node_ref
+                    }
+                };
+                match node_ref {
+                    NodeRef::Digest(digest) => B256::from_slice(digest),
+                    NodeRef::Bytes(bytes) => keccak256(bytes),
+                }
+            }
+        }
+    }
+
+    /// Retrieves the value associated with a given key in the trie.
+    #[inline]
+    pub fn get<'s>(&'s self, key: &[u8]) -> Result<Option<&'a [u8]>, Error> {
+        self.get_internal(self.root_id, &to_nibs(key))
+    }
+
+    /// Retrieves the RLP-decoded value corresponding to the key.
+    #[inline]
+    pub fn get_rlp<T: alloy_rlp::Decodable>(&self, key: &[u8]) -> Result<Option<T>, Error> {
+        match self.get(key)? {
+            Some(bytes) => {
+                let mut slice = bytes;
+                Ok(Some(T::decode(&mut slice)?))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Inserts a key-value pair into the trie.
+    #[inline]
+    pub fn insert(&mut self, key: &[u8], value: &'a [u8]) -> Result<bool, Error> {
+        let key_nibs = &to_nibs(key);
+        self.insert_internal(self.root_id, key_nibs, value)
+    }
+
+    /// Inserts an RLP-encoded value into the trie.
+    #[inline]
+    pub fn insert_rlp(
+        &mut self,
+        key: &[u8],
+        value: impl alloy_rlp::Encodable,
+    ) -> Result<bool, Error> {
+        let mut rlp_bytes = BumpBytesMut::with_capacity_in(VALUE_RLP_BUFFER_CAPACITY, self.bump);
+        value.encode(&mut rlp_bytes);
+        self.insert(key, rlp_bytes.into_inner().into_bump_slice())
+    }
+
+    /// Removes a key from the trie.
+    ///
+    /// This method attempts to remove a key-value pair from the trie. If the key is
+    /// present, it returns `true`. Otherwise, it returns `false`.
+    #[inline]
+    pub fn delete(&mut self, key: &[u8]) -> Result<bool, Error> {
+        let key_nibs = &to_nibs(key);
+        self.delete_internal(self.root_id, key_nibs)
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        matches!(&self.nodes[self.root_id as usize], NodeData::Null)
+    }
+
+    /// Reserves additional capacity for the trie.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.nodes.reserve(additional);
+        self.cached_references.reserve(additional);
+    }
+}
+
+// Internal Implementation
+impl<'a> Mpt<'a> {
+    #[inline]
+    pub(crate) fn add_node(&mut self, data: NodeData<'a>, node_ref: Option<NodeRef<'a>>) -> NodeId {
+        let id = self.nodes.len() as NodeId;
+        self.nodes.push(data);
+        self.cached_references.push(Cell::new(node_ref));
+        id
+    }
+
+    /// Sets the root node ID. Used for testing to construct tries with specific structure.
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn set_root_id(&mut self, root_id: NodeId) {
+        self.root_id = root_id;
+    }
+
+    #[inline]
+    fn invalidate_ref_cache(&mut self, node_id: NodeId) {
+        self.cached_references[node_id as usize].set(None);
+    }
+
+    #[inline]
+    fn get_internal(&self, node_id: NodeId, key_nibs: &[u8]) -> Result<Option<&'a [u8]>, Error> {
+        match &self.nodes[node_id as usize] {
+            NodeData::Null => Ok(None),
+            NodeData::Branch(nodes) => {
+                if let Some((i, tail)) = key_nibs.split_first() {
+                    match nodes[*i as usize] {
+                        Some(id) => self.get_internal(id, tail),
+                        None => Ok(None),
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+            NodeData::Leaf(path_bytes, value) => {
+                // Compare compact path to key nibbles without allocating
+                if encoded_path_eq_nibs(path_bytes, key_nibs) {
+                    Ok(Some(value))
+                } else {
+                    Ok(None)
+                }
+            }
+            NodeData::Extension(path_bytes, child_id) => {
+                // Strip compact path prefix without allocating
+                if let Some(tail) = encoded_path_strip_prefix(path_bytes, key_nibs) {
+                    self.get_internal(*child_id, tail)
+                } else {
+                    Ok(None)
+                }
+            }
+            NodeData::Digest(digest) => Err(Error::NodeNotResolved(B256::from_slice(digest))),
+        }
+    }
+
+    #[inline]
+    fn insert_internal(
+        &mut self,
+        node_id: NodeId,
+        key_nibs: &[u8],
+        value: &'a [u8],
+    ) -> Result<bool, Error> {
+        let updated = match self.nodes[node_id as usize] {
+            NodeData::Null => {
+                let path = to_encoded_path_with_bump(self.bump, key_nibs, true);
+                self.nodes[node_id as usize] = NodeData::Leaf(path, value);
+                true
+            }
+            NodeData::Branch(mut children) => {
+                if let Some((i, tail)) = key_nibs.split_first() {
+                    match children[*i as usize] {
+                        Some(id) => self.insert_internal(id, tail, value)?,
+                        None => {
+                            let path = to_encoded_path_with_bump(self.bump, tail, true);
+                            let new_leaf_id = self.add_node(NodeData::Leaf(path, value), None);
+                            children[*i as usize] = Some(new_leaf_id);
+                            self.nodes[node_id as usize] = NodeData::Branch(children);
+                            true
+                        }
+                    }
+                } else {
+                    return Err(Error::ValueInBranch);
+                }
+            }
+            NodeData::Leaf(prefix, old_value) => {
+                if encoded_path_eq_nibs(prefix, key_nibs) {
+                    // update the value if it is different
+                    if old_value == value {
+                        return Ok(false);
+                    }
+                    self.nodes[node_id as usize] = NodeData::Leaf(prefix, value);
+                    true
+                } else {
+                    let self_nibs = prefix_to_nibs(prefix);
+                    let common_len = lcp(&self_nibs, key_nibs);
+
+                    if common_len == self_nibs.len() || common_len == key_nibs.len() {
+                        return Err(Error::ValueInBranch);
+                    } else {
+                        // otherwise, create a branch with two children
+                        let split_point = common_len + 1;
+                        let mut children: [Option<NodeId>; 16] = Default::default();
+
+                        let leaf1_path =
+                            to_encoded_path_with_bump(self.bump, &self_nibs[split_point..], true);
+                        let leaf1_id = self.add_node(NodeData::Leaf(leaf1_path, old_value), None);
+
+                        let leaf2_path =
+                            to_encoded_path_with_bump(self.bump, &key_nibs[split_point..], true);
+                        let leaf2_id = self.add_node(NodeData::Leaf(leaf2_path, value), None);
+
+                        children[self_nibs[common_len] as usize] = Some(leaf1_id);
+                        children[key_nibs[common_len] as usize] = Some(leaf2_id);
+
+                        let new_node_data = if common_len > 0 {
+                            let branch_id = self.add_node(NodeData::Branch(children), None);
+                            let ext_path_slice = to_encoded_path_with_bump(
+                                self.bump,
+                                &self_nibs[..common_len],
+                                false,
+                            );
+                            NodeData::Extension(ext_path_slice, branch_id)
+                        } else {
+                            NodeData::Branch(children)
+                        };
+                        self.nodes[node_id as usize] = new_node_data;
+                        true
+                    }
+                }
+            }
+            NodeData::Extension(prefix, child_id) => {
+                if let Some(tail) = encoded_path_strip_prefix(prefix, key_nibs) {
+                    self.insert_internal(child_id, tail, value)?
+                } else {
+                    let self_nibs = prefix_to_nibs(prefix);
+                    let common_len = lcp(&self_nibs, key_nibs);
+
+                    if common_len == key_nibs.len() {
+                        return Err(Error::ValueInBranch);
+                    }
+                    let split_point = common_len + 1;
+                    let mut children: [Option<NodeId>; 16] = Default::default();
+
+                    if split_point < self_nibs.len() {
+                        let ext_path =
+                            to_encoded_path_with_bump(self.bump, &self_nibs[split_point..], false);
+                        let ext_id = self.add_node(NodeData::Extension(ext_path, child_id), None);
+                        children[self_nibs[common_len] as usize] = Some(ext_id);
+                    } else {
+                        children[self_nibs[common_len] as usize] = Some(child_id);
+                    }
+
+                    let leaf_path =
+                        to_encoded_path_with_bump(self.bump, &key_nibs[split_point..], true);
+                    let leaf_id = self.add_node(NodeData::Leaf(leaf_path, value), None);
+                    children[key_nibs[common_len] as usize] = Some(leaf_id);
+
+                    let new_node_data = if common_len > 0 {
+                        let branch_id = self.add_node(NodeData::Branch(children), None);
+                        let parent_ext_path_slice =
+                            to_encoded_path_with_bump(self.bump, &self_nibs[..common_len], false);
+                        NodeData::Extension(parent_ext_path_slice, branch_id)
+                    } else {
+                        NodeData::Branch(children)
+                    };
+                    self.nodes[node_id as usize] = new_node_data;
+                    true
+                }
+            }
+            NodeData::Digest(digest) => {
+                return Err(Error::NodeNotResolved(B256::from_slice(digest)));
+            }
+        };
+
+        if updated {
+            self.invalidate_ref_cache(node_id);
+        }
+
+        Ok(updated)
+    }
+
+    #[inline]
+    fn delete_internal(&mut self, node_id: NodeId, key_nibs: &[u8]) -> Result<bool, Error> {
+        let updated = match self.nodes[node_id as usize] {
+            NodeData::Null => false,
+            NodeData::Branch(mut children) => {
+                if let Some((i, tail)) = key_nibs.split_first() {
+                    let child_id = children[*i as usize];
+                    match child_id {
+                        Some(id) => {
+                            if !self.delete_internal(id, tail)? {
+                                return Ok(false);
+                            }
+
+                            // if the node is now empty, remove it
+                            if matches!(self.nodes[id as usize], NodeData::Null) {
+                                children[*i as usize] = None;
+                            }
+                        }
+                        None => return Ok(false),
+                    }
+                } else {
+                    return Err(Error::ValueInBranch);
+                }
+
+                let mut remaining_iter = children.iter().enumerate().filter(|(_, n)| n.is_some());
+
+                // there will always be at least one remaining node
+                let (index, child_id) = remaining_iter.next().unwrap();
+                let child_id = child_id.unwrap();
+
+                // if there is only exactly one node left, we need to convert the branch
+                if remaining_iter.next().is_none() {
+                    let child_node_data = self.nodes[child_id as usize].clone();
+
+                    let new_node_data = match child_node_data {
+                        NodeData::Leaf(prefix, value) => {
+                            let leaf_nibs = prefix_to_nibs(prefix);
+                            let mut new_nibs: SmallVec<[u8; 64]> =
+                                SmallVec::with_capacity(1 + leaf_nibs.len());
+                            new_nibs.push(index as u8);
+                            new_nibs.extend_from_slice(&leaf_nibs);
+                            let new_path = to_encoded_path_with_bump(self.bump, &new_nibs, true);
+                            NodeData::Leaf(new_path, value)
+                        }
+                        NodeData::Extension(prefix, child_child_id) => {
+                            let ext_nibs = prefix_to_nibs(prefix);
+                            let mut new_nibs: SmallVec<[u8; 64]> =
+                                SmallVec::with_capacity(1 + ext_nibs.len());
+                            new_nibs.push(index as u8);
+                            new_nibs.extend_from_slice(&ext_nibs);
+                            let new_path = to_encoded_path_with_bump(self.bump, &new_nibs, false);
+                            NodeData::Extension(new_path, child_child_id)
+                        }
+                        NodeData::Branch(_) => {
+                            let ext_nibs: SmallVec<[u8; 1]> = SmallVec::from_slice(&[index as u8]);
+                            let new_path = to_encoded_path_with_bump(self.bump, &ext_nibs, false);
+                            NodeData::Extension(new_path, child_id)
+                        }
+                        NodeData::Digest(digest) => {
+                            return Err(Error::NodeNotResolved(B256::from_slice(digest)));
+                        }
+                        NodeData::Null => unreachable!(),
+                    };
+                    self.nodes[node_id as usize] = new_node_data;
+                } else {
+                    self.nodes[node_id as usize] = NodeData::Branch(children);
+                }
+
+                true
+            }
+            NodeData::Leaf(prefix, _) => {
+                if !encoded_path_eq_nibs(prefix, key_nibs) {
+                    return Ok(false);
+                }
+                self.nodes[node_id as usize] = NodeData::Null;
+                true
+            }
+            NodeData::Extension(prefix, child_id) => {
+                let tail = match encoded_path_strip_prefix(prefix, key_nibs) {
+                    Some(tail) => tail,
+                    None => return Ok(false),
+                };
+                if !self.delete_internal(child_id, tail)? {
+                    return Ok(false);
+                }
+
+                // an extension can only point to a branch or a digest; since it's sub trie was
+                // modified, we need to make sure that this property still holds
+                let self_nibs = prefix_to_nibs(prefix);
+                let child_node_data = &self.nodes[child_id as usize];
+                let new_node_data = match child_node_data {
+                    // if the child is empty, remove the extension
+                    NodeData::Null => NodeData::Null,
+                    // for a leaf, replace the extension with the extended leaf
+                    NodeData::Leaf(child_path_bytes, value) => {
+                        let child_path_nibs = prefix_to_nibs(child_path_bytes);
+                        let mut combined_nibs: SmallVec<[u8; 64]> =
+                            SmallVec::with_capacity(self_nibs.len() + child_path_nibs.len());
+                        combined_nibs.extend_from_slice(&self_nibs);
+                        combined_nibs.extend_from_slice(&child_path_nibs);
+                        let new_path = to_encoded_path_with_bump(self.bump, &combined_nibs, true);
+                        NodeData::Leaf(new_path, value)
+                    }
+                    // for an extension, replace the extension with the extended extension
+                    NodeData::Extension(child_path_bytes, grandchild_id) => {
+                        let child_path_nibs = prefix_to_nibs(child_path_bytes);
+                        let mut combined_nibs: SmallVec<[u8; 64]> =
+                            SmallVec::with_capacity(self_nibs.len() + child_path_nibs.len());
+                        combined_nibs.extend_from_slice(&self_nibs);
+                        combined_nibs.extend_from_slice(&child_path_nibs);
+                        let new_path = to_encoded_path_with_bump(self.bump, &combined_nibs, false);
+                        NodeData::Extension(new_path, *grandchild_id)
+                    }
+                    // for a branch, the extension is still correct
+                    NodeData::Branch(_) => NodeData::Extension(prefix, child_id),
+                    // for a digest, we don't know the node type so we can't safely canonicalize
+                    NodeData::Digest(digest) => {
+                        return Err(Error::NodeNotResolved(B256::from_slice(digest)));
+                    }
+                };
+                self.nodes[node_id as usize] = new_node_data;
+                true
+            }
+            NodeData::Digest(digest) => {
+                return Err(Error::NodeNotResolved(B256::from_slice(digest)));
+            }
+        };
+
+        if updated {
+            self.invalidate_ref_cache(node_id);
+        }
+        Ok(updated)
+    }
+}
+
+impl Mpt<'_> {
+    pub fn print_trie(&self) {
+        self.print_trie_internal(self.root_id, 0);
+    }
+
+    fn print_trie_internal(&self, node_id: NodeId, depth: usize) {
+        let indent = "  ".repeat(depth);
+        match &self.nodes[node_id as usize] {
+            NodeData::Null => {
+                println!("{}Null", indent);
+            }
+            NodeData::Branch(children) => {
+                println!("{}Branch", indent);
+                for (i, child) in children.iter().enumerate() {
+                    if let Some(child_id) = child {
+                        println!("{}  [{}]:", indent, hex::encode([i as u8]));
+                        self.print_trie_internal(*child_id, depth + 2);
+                    }
+                }
+            }
+            NodeData::Leaf(path, value) => {
+                println!("{}Leaf path={} value_len={}", indent, hex::encode(path), value.len());
+            }
+            NodeData::Extension(path, child_id) => {
+                println!("{}Extension path={}", indent, hex::encode(path));
+                self.print_trie_internal(*child_id, depth + 1);
+            }
+            NodeData::Digest(digest) => {
+                println!("{}Digest {:?}", indent, B256::from_slice(digest));
+            }
+        }
+    }
+}

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -23,8 +23,9 @@ use mpt::{
 };
 
 /// Legacy pointer-based MPT node — used host-side to build the witness from RPC proofs before
-/// re-encoding into the arena codec. In the arena guest path it is not used (the guest only sees
-/// the arena form); in the legacy guest path the whole [`EthereumState`] is deserialized directly.
+/// re-encoding into the arena codec. In the arena guest path it is not used (the guest only
+/// sees the arena form); in the legacy guest path the whole [`EthereumState`] is deserialized
+/// directly.
 pub use mpt::MptNode;
 
 /// Ethereum state trie and account storage tries.
@@ -174,12 +175,12 @@ impl EthereumState {
     ///      [`ArenaTries::update`]'s no-storage-change fallback, then into the state-trie leaf,
     ///      then into the final state-trie root via the hashes-of-children chain.
     ///   2. The guest's `ClientExecutor::execute` compares the final state root against
-    ///      `input.current_block.header().state_root()` and returns `MismatchedStateRoot` on
-    ///      any disagreement (flagged with a `SOUNDNESS:` tag in
+    ///      `input.current_block.header().state_root()` and returns `MismatchedStateRoot` on any
+    ///      disagreement (flagged with a `SOUNDNESS:` tag in
     ///      `crates/executor/client/src/executor.rs`).
-    ///   3. The host can't forge an `input.current_block.header().state_root()` matching a
-    ///      tampered psr because the committed header is checked by the external verifier
-    ///      against the canonical chain.
+    ///   3. The host can't forge an `input.current_block.header().state_root()` matching a tampered
+    ///      psr because the committed header is checked by the external verifier against the
+    ///      canonical chain.
     ///
     /// Any divergence in psr therefore surfaces as a guest-side error and no proof is produced.
     /// The integration test `psr_tamper_changes_state_root` in this module is the executable
@@ -571,16 +572,15 @@ mod arena_integration_tests {
     /// its bytes. We rely on the executor's final `state_root != block.header.state_root`
     /// check to catch any tampering. This test makes that property executable: it
     ///
-    ///   1. Builds an `EthereumState` where one account has non-empty storage_root and
-    ///      another's state will be updated **without** touching its storage (the only path
-    ///      that consults psr).
+    ///   1. Builds an `EthereumState` where one account has non-empty storage_root and another's
+    ///      state will be updated **without** touching its storage (the only path that consults
+    ///      psr).
     ///   2. Encodes to arena witness, decodes, applies `update`, records the "honest" root.
-    ///   3. Re-encodes, **flips bits in the psr entry's storage_root** for the affected
-    ///      account, decodes the tampered blob, applies the same update, records the
-    ///      "tampered" root.
-    ///   4. Asserts that `honest_root != tampered_root` — i.e., any tamper in psr
-    ///      deterministically changes the computed state root, which the executor's
-    ///      `MismatchedStateRoot` check would surface as a hard error.
+    ///   3. Re-encodes, **flips bits in the psr entry's storage_root** for the affected account,
+    ///      decodes the tampered blob, applies the same update, records the "tampered" root.
+    ///   4. Asserts that `honest_root != tampered_root` — i.e., any tamper in psr deterministically
+    ///      changes the computed state root, which the executor's `MismatchedStateRoot` check would
+    ///      surface as a hard error.
     ///
     /// If anyone weakens or removes the executor's final check, the soundness chain breaks
     /// and this test (or its property) needs re-evaluation. See the `SOUNDNESS:` tag at

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use alloy_primitives::{keccak256, map::HashMap, Address, B256};
+use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
+use alloy_rlp::Decodable;
 use alloy_rpc_types::EIP1186AccountProofResponse;
 use reth_trie::{AccountProof, HashedPostState, HashedStorage, TrieAccount};
 use serde::{Deserialize, Serialize};
@@ -11,10 +12,20 @@ mod execution_witness;
 /// Module containing MPT code adapted from `zeth`.
 mod mpt;
 pub use mpt::Error;
+
+/// Arena-based, zero-copy MPT used as the witness format on the host->guest boundary
+/// (ported from `openvm-eth`). This is the alternative backend to the pointer-based
+/// [`MptNode`] state, selected via the `arena` cargo feature on the client/host binaries.
+pub mod arena;
+
 use mpt::{
     mpt_from_proof, parse_proof, proofs_to_tries, resolve_nodes, transition_proofs_to_tries,
-    MptNode,
 };
+
+/// Legacy pointer-based MPT node — used host-side to build the witness from RPC proofs before
+/// re-encoding into the arena codec. In the arena guest path it is not used (the guest only sees
+/// the arena form); in the legacy guest path the whole [`EthereumState`] is deserialized directly.
+pub use mpt::MptNode;
 
 /// Ethereum state trie and account storage tries.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -131,6 +142,364 @@ impl EthereumState {
     pub fn state_root(&self) -> B256 {
         self.state_trie.hash()
     }
+
+    /// Encodes the state into a single flat byte blob in the arena codec — the zero-copy
+    /// witness used by the `arena` guest path. All tries are `encode_trie`d and concatenated
+    /// with framing (num_nodes/length/key), and the guest reconstructs them zero-copy by
+    /// borrowing the blob directly with [`ArenaTries::decode`].
+    ///
+    /// Wire layout:
+    /// ```text
+    /// [state_trie: num_nodes:u32 | len:u32 | bytes:len]
+    /// [num_storage_tries:u32]
+    /// [storage_tries: per entry { addr:32 | num_nodes:u32 | len:u32 | bytes:len }]
+    /// [num_psr:u32]
+    /// [psr: per entry { hashed_address:32 | storage_root:32 } sorted by hashed_address]
+    /// ```
+    ///
+    /// The trailing `psr` section is the **pre-state storage_root cache**: for every revealed
+    /// account in `state_trie`, the `storage_root` field of its account leaf. Sorted by
+    /// hashed_address so the guest's [`ArenaTries::update`] coordinated walk is O(N+M).
+    ///
+    /// Why we ship this: canonical witness mode omits storage tries for accounts whose state
+    /// changes but whose storage isn't touched in the block. Without the cache, the guest has
+    /// to walk the state trie to recover each affected account's pre-existing storage_root —
+    /// O(depth) per fallback. With the cache, it's a single linear scan across the whole
+    /// update. See [`ArenaTries::update`] for the consumer side.
+    ///
+    /// SOUNDNESS: the psr section is **not separately hash-committed**. The host can put any
+    /// value (or omit entries, or include spurious ones). The cache is sound because:
+    ///
+    ///   1. Every cached `storage_root` flows into a `state_account.storage_root` in
+    ///      [`ArenaTries::update`]'s no-storage-change fallback, then into the state-trie leaf,
+    ///      then into the final state-trie root via the hashes-of-children chain.
+    ///   2. The guest's `ClientExecutor::execute` compares the final state root against
+    ///      `input.current_block.header().state_root()` and returns `MismatchedStateRoot` on
+    ///      any disagreement (flagged with a `SOUNDNESS:` tag in
+    ///      `crates/executor/client/src/executor.rs`).
+    ///   3. The host can't forge an `input.current_block.header().state_root()` matching a
+    ///      tampered psr because the committed header is checked by the external verifier
+    ///      against the canonical chain.
+    ///
+    /// Any divergence in psr therefore surfaces as a guest-side error and no proof is produced.
+    /// The integration test `psr_tamper_changes_state_root` in this module is the executable
+    /// regression check for this property.
+    pub fn to_arena_witness(&self) -> Vec<u8> {
+        fn put_u32(blob: &mut Vec<u8>, v: usize) {
+            blob.extend_from_slice(&(v as u32).to_le_bytes());
+        }
+        fn put_trie(blob: &mut Vec<u8>, node: &MptNode) {
+            let bump = bumpalo::Bump::new();
+            let trie = arena::Mpt::from_mpt_node(&bump, node);
+            let bytes = trie.encode_trie();
+            put_u32(blob, trie.num_nodes());
+            put_u32(blob, bytes.len());
+            blob.extend_from_slice(&bytes);
+        }
+
+        let mut blob = Vec::new();
+        put_trie(&mut blob, &self.state_trie);
+        put_u32(&mut blob, self.storage_tries.len());
+        for (key, node) in &self.storage_tries {
+            blob.extend_from_slice(key.as_slice());
+            put_trie(&mut blob, node);
+        }
+
+        // Pre-state storage_root cache: walk every revealed account leaf, RLP-decode it to
+        // pull the `storage_root` field, push `(hashed_address, storage_root)` into a Vec, sort
+        // lex by hashed_address. The walk + decode is host CPU only (not proven), so its cost
+        // is irrelevant — the gain is in the guest where this section replaces ~250
+        // `state_trie.get_rlp::<TrieAccount>` calls per block.
+        let mut psr: Vec<(B256, B256)> = Vec::new();
+        self.state_trie.for_each_leaves(|key, mut value| {
+            let account = TrieAccount::decode(&mut value).unwrap();
+            psr.push((B256::from_slice(key), account.storage_root));
+        });
+        psr.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        put_u32(&mut blob, psr.len());
+        for (hashed_address, storage_root) in &psr {
+            blob.extend_from_slice(hashed_address.as_slice());
+            blob.extend_from_slice(storage_root.as_slice());
+        }
+        blob
+    }
+}
+
+/// Decoded arena tries — the guest-side equivalent of [`EthereumState`] for the `arena` path.
+/// Borrows the bump and the witness blob for the duration of block execution; provides
+/// account/storage lookups, `update`, and `state_root`.
+#[derive(Debug)]
+pub struct ArenaTries<'a> {
+    bump: &'a bumpalo::Bump,
+    pub state_trie: arena::Mpt<'a>,
+    pub storage_tries: HashMap<B256, arena::Mpt<'a>>,
+    /// Pre-state `storage_root` per revealed account, sorted by `hashed_address`. Stored
+    /// zero-copy as a packed slice (`[hashed_address:32 | storage_root:32]*`). Consumed by
+    /// `update` to skip the per-account state-trie walk on the canonical-mode "state changed
+    /// but storage untouched" path. See [`EthereumState::to_arena_witness`] for the producer.
+    ///
+    /// SOUNDNESS: this slice is **untrusted host input** — there is no separate Merkle
+    /// commitment over its contents. Soundness derives entirely from the final state-root
+    /// check in `ClientExecutor::execute`: any tampered value propagates into the
+    /// `state_account.storage_root` of a state-trie leaf, then into the trie root, and the
+    /// resulting mismatch surfaces as `MismatchedStateRoot`. See the `SOUNDNESS:` tag in
+    /// `crates/executor/client/src/executor.rs` and the regression test
+    /// `psr_tamper_changes_state_root` in this crate's tests.
+    pre_state_storage_roots: &'a [u8],
+}
+
+/// Wire-format constant: bytes per `(hashed_address, storage_root)` entry in the psr section.
+const PSR_ENTRY: usize = 64;
+
+impl<'a> ArenaTries<'a> {
+    /// Decodes the witness blob into arena tries that borrow `bump` and `blob` directly — no
+    /// copy of the witness, one bump allocation, each node's hash verified inline by
+    /// [`arena::Mpt::decode_trie`].
+    pub fn decode(bump: &'a bumpalo::Bump, blob: &'a [u8]) -> Result<Self, arena::Error> {
+        fn read_u32(blob: &[u8], pos: &mut usize) -> usize {
+            let v = u32::from_le_bytes(blob[*pos..*pos + 4].try_into().unwrap()) as usize;
+            *pos += 4;
+            v
+        }
+
+        let mut pos = 0usize;
+        let decode_trie = |pos: &mut usize| -> Result<arena::Mpt<'a>, arena::Error> {
+            let num_nodes = read_u32(blob, pos);
+            let len = read_u32(blob, pos);
+            let mut bytes: &'a [u8] = &blob[*pos..*pos + len];
+            *pos += len;
+            arena::Mpt::decode_trie(bump, &mut bytes, num_nodes)
+        };
+
+        let state_trie = decode_trie(&mut pos)?;
+        let count = read_u32(blob, &mut pos);
+        let mut storage_tries = HashMap::with_hasher(Default::default());
+        for _ in 0..count {
+            let key = B256::from_slice(&blob[pos..pos + 32]);
+            pos += 32;
+            let trie = decode_trie(&mut pos)?;
+            storage_tries.insert(key, trie);
+        }
+
+        // Pre-state storage_root cache: zero-copy slice into the blob, sorted by hashed_address.
+        let psr_count = read_u32(blob, &mut pos);
+        let psr_end = pos + psr_count * PSR_ENTRY;
+        let pre_state_storage_roots: &'a [u8] = &blob[pos..psr_end];
+
+        Ok(ArenaTries { bump, state_trie, storage_tries, pre_state_storage_roots })
+    }
+}
+
+impl ArenaTries<'_> {
+    /// Mutates state based on diffs provided in [`HashedPostState`] (mirrors
+    /// [`EthereumState::update`] on the arena tries).
+    ///
+    /// Applies changes in the canonical-witness-spec order (keys sorted lexicographically
+    /// ascending, inserts/updates before deletes, at both storage and state-trie levels). This
+    /// order is what the `Canonical` `ExecutionWitnessMode` assumes when emitting siblings;
+    /// legacy mode tolerates any order (its sibling set is a superset), so the single
+    /// implementation works for both witness shapes. Falls back to reading the pre-existing
+    /// storage_root from the psr cache when the witness omits the storage trie (canonical mode
+    /// for storage-untouched accounts).
+    pub fn update(&mut self, post_state: &HashedPostState) {
+        type AcctRef<'a> = (
+            &'a B256,
+            Option<&'a reth_primitives_traits::Account>,
+            Option<&'a reth_trie::HashedStorage>,
+        );
+
+        let mut accounts_sorted: Vec<AcctRef<'_>> = post_state
+            .accounts
+            .iter()
+            .map(|(k, v)| (k, v.as_ref(), post_state.storages.get(k)))
+            .collect();
+        accounts_sorted.sort_unstable_by(|a, b| a.0.cmp(b.0));
+
+        let mut slot_inserts: Vec<(B256, U256)> = Vec::with_capacity(32);
+        let mut slot_deletes: Vec<B256> = Vec::with_capacity(32);
+
+        // Coordinated walk through pre_state_storage_roots: both lists are sorted by
+        // hashed_address, so a single monotonic cursor across the entire update() makes the
+        // fallback lookup O(1) amortized instead of O(trie_depth) per missing-storage-change
+        // account.
+        let psr = self.pre_state_storage_roots;
+        let psr_count = psr.len() / PSR_ENTRY;
+        let mut psr_idx: usize = 0;
+
+        // Pass 1: storage tries + state-trie inserts/updates (sorted).
+        for entry in &accounts_sorted {
+            let hashed_address: &B256 = entry.0;
+            let Some(account) = entry.1 else { continue };
+            let storage_change: Option<&reth_trie::HashedStorage> = entry.2;
+
+            let storage_root = if let Some(ss) = storage_change {
+                // Storage touched — apply two-pass canonical update to the storage trie.
+                let storage_trie = self
+                    .storage_tries
+                    .entry(*hashed_address)
+                    .or_insert_with(|| arena::Mpt::new(self.bump));
+                if ss.wiped {
+                    *storage_trie = arena::Mpt::new(self.bump);
+                }
+
+                slot_inserts.clear();
+                slot_deletes.clear();
+                for (k, v) in ss.storage.iter() {
+                    if v.is_zero() {
+                        slot_deletes.push(*k);
+                    } else {
+                        slot_inserts.push((*k, *v));
+                    }
+                }
+                slot_inserts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                slot_deletes.sort_unstable();
+
+                for (k, v) in &slot_inserts {
+                    storage_trie.insert_rlp(k.as_slice(), *v).unwrap();
+                }
+                for k in &slot_deletes {
+                    storage_trie.delete(k.as_slice()).unwrap();
+                }
+
+                storage_trie.hash()
+            } else {
+                // Storage NOT touched — read the pre-existing storage_root from the sorted
+                // psr slice. Advance `psr_idx` until the key is >= hashed_address; if it
+                // matches, use the cached storage_root; otherwise the account is new and its
+                // storage_root is EMPTY (which is also what arena::Mpt::new(bump).hash() would
+                // produce, matching the host's `to_arena_witness` for unrevealed accounts).
+                //
+                // SOUNDNESS: `psr` is host-controlled and not hash-committed. A tampered value
+                // here flows into `state_account.storage_root` below, into the state-trie leaf,
+                // and into the final state root — caught by the executor's
+                // `MismatchedStateRoot` check. See the field doc + executor `SOUNDNESS:` tag.
+                let target = hashed_address.as_slice();
+                let mut found = reth_trie::EMPTY_ROOT_HASH;
+                while psr_idx < psr_count {
+                    let off = psr_idx * PSR_ENTRY;
+                    let key = &psr[off..off + 32];
+                    if key < target {
+                        psr_idx += 1;
+                    } else {
+                        if key == target {
+                            found = B256::from_slice(&psr[off + 32..off + 64]);
+                        }
+                        break;
+                    }
+                }
+                found
+            };
+
+            let state_account = TrieAccount {
+                nonce: account.nonce,
+                balance: account.balance,
+                storage_root,
+                code_hash: account.get_bytecode_hash(),
+            };
+            self.state_trie.insert_rlp(hashed_address.as_slice(), state_account).unwrap();
+        }
+
+        // Pass 2: state-trie deletes (sorted).
+        for entry in &accounts_sorted {
+            if entry.1.is_none() {
+                self.state_trie.delete(entry.0.as_slice()).unwrap();
+            }
+        }
+    }
+
+    /// Computes the state root.
+    pub fn state_root(&self) -> B256 {
+        self.state_trie.hash()
+    }
+}
+
+/// Backend-agnostic view over the Ethereum state + storage tries consumed by the client
+/// executor. Implemented by both the pointer-based [`EthereumState`] (legacy, the default
+/// backend) and the arena-based [`ArenaTries`] (selected via the `arena` cargo feature on the
+/// client/host binaries).
+///
+/// This mirrors the trie seam of `paradigmxyz/stateless`'s `StatelessTrie`, adapted to rsp's
+/// witness formats: construction differs per backend (bincode-`EthereumState` vs the flat arena
+/// blob), so it stays backend-specific and is not part of this trait — only the read/verify/
+/// update operations the executor drives generically live here.
+pub trait StateTries {
+    /// Root hash of the state trie.
+    fn state_root(&self) -> B256;
+
+    /// Account at `hashed_address` (`keccak256(address)`), if revealed by the witness.
+    fn account(&self, hashed_address: B256) -> Option<TrieAccount>;
+
+    /// Storage slot value at `(hashed_address, hashed_slot)`, where `hashed_slot =
+    /// keccak256(slot_key)`. Returns zero for an unset slot.
+    fn storage_value(&self, hashed_address: B256, hashed_slot: B256) -> U256;
+
+    /// Iterator of `(hashed_address, storage_root)` over every revealed storage trie — used
+    /// during witness-db construction to verify each storage root against its account leaf.
+    fn storage_roots(&self) -> impl Iterator<Item = (B256, B256)> + '_;
+
+    /// Applies the post-execution [`HashedPostState`] diff to the tries.
+    fn update(&mut self, post_state: &HashedPostState);
+}
+
+impl StateTries for EthereumState {
+    fn state_root(&self) -> B256 {
+        // Inherent methods take precedence, so this dispatches to `EthereumState::state_root`.
+        EthereumState::state_root(self)
+    }
+
+    fn account(&self, hashed_address: B256) -> Option<TrieAccount> {
+        self.state_trie.get_rlp::<TrieAccount>(hashed_address.as_slice()).unwrap()
+    }
+
+    fn storage_value(&self, hashed_address: B256, hashed_slot: B256) -> U256 {
+        let storage_trie = self
+            .storage_tries
+            .get(&hashed_address)
+            .expect("A storage trie must be provided for each account");
+        storage_trie
+            .get_rlp::<U256>(hashed_slot.as_slice())
+            .expect("Can get from MPT")
+            .unwrap_or_default()
+    }
+
+    fn storage_roots(&self) -> impl Iterator<Item = (B256, B256)> + '_ {
+        self.storage_tries.iter().map(|(hashed_address, trie)| (*hashed_address, trie.hash()))
+    }
+
+    fn update(&mut self, post_state: &HashedPostState) {
+        EthereumState::update(self, post_state)
+    }
+}
+
+impl StateTries for ArenaTries<'_> {
+    fn state_root(&self) -> B256 {
+        ArenaTries::state_root(self)
+    }
+
+    fn account(&self, hashed_address: B256) -> Option<TrieAccount> {
+        self.state_trie.get_rlp::<TrieAccount>(hashed_address.as_slice()).unwrap()
+    }
+
+    fn storage_value(&self, hashed_address: B256, hashed_slot: B256) -> U256 {
+        // Missing storage trie => zero for any slot: either canonical mode dropped an
+        // empty-storage_root trie, or the account is newly created this block. A genuinely
+        // missing non-empty trie surfaces later as `MismatchedStateRoot`.
+        let Some(storage_trie) = self.storage_tries.get(&hashed_address) else {
+            return U256::ZERO;
+        };
+        storage_trie
+            .get_rlp::<U256>(hashed_slot.as_slice())
+            .expect("Can get from MPT")
+            .unwrap_or_default()
+    }
+
+    fn storage_roots(&self) -> impl Iterator<Item = (B256, B256)> + '_ {
+        self.storage_tries.iter().map(|(hashed_address, trie)| (*hashed_address, trie.hash()))
+    }
+
+    fn update(&mut self, post_state: &HashedPostState) {
+        ArenaTries::update(self, post_state)
+    }
 }
 
 impl core::fmt::Debug for EthereumState {
@@ -142,6 +511,200 @@ impl core::fmt::Debug for EthereumState {
         let ordered: std::collections::BTreeMap<_, _> = self.storage_tries.iter().collect();
         ds.field("storage_tries", &ordered);
         ds.finish()
+    }
+}
+
+#[cfg(test)]
+mod arena_integration_tests {
+    use alloy_primitives::{keccak256, U256};
+    use bumpalo::Bump;
+    use reth_trie::EMPTY_ROOT_HASH;
+
+    use super::*;
+
+    /// The arena witness path (EthereumState -> to_arena_witness -> decode -> ArenaTries) must
+    /// reproduce the exact state/storage roots and account lookups of the legacy MptNode state.
+    #[test]
+    fn test_arena_witness_roundtrip_state() {
+        // A storage trie for one account.
+        let mut storage = MptNode::default();
+        for i in 0..50u64 {
+            storage.insert_rlp(keccak256(i.to_be_bytes()).as_slice(), U256::from(i + 1)).unwrap();
+        }
+        let storage_root = storage.hash();
+        let addr_hash = keccak256([7u8; 20]);
+
+        // A state trie of TrieAccount leaves; account 0 points at the storage trie above.
+        let mut state_trie = MptNode::default();
+        for i in 0..200u64 {
+            let account = TrieAccount {
+                nonce: i,
+                balance: U256::from(i) * U256::from(1000u64),
+                storage_root: if i == 0 { storage_root } else { EMPTY_ROOT_HASH },
+                code_hash: keccak256([]),
+            };
+            let key = if i == 0 { addr_hash } else { keccak256(i.to_be_bytes()) };
+            state_trie.insert_rlp(key.as_slice(), account).unwrap();
+        }
+
+        let mut storage_tries = HashMap::with_hasher(Default::default());
+        storage_tries.insert(addr_hash, storage);
+        let state = EthereumState { state_trie, storage_tries };
+        let state_root = state.state_root();
+
+        // Round-trip through the arena codec.
+        let witness = state.to_arena_witness();
+        let bump = Bump::new();
+        let tries = ArenaTries::decode(&bump, &witness).unwrap();
+
+        assert_eq!(tries.state_root(), state_root, "arena state root mismatch");
+        assert_eq!(tries.storage_tries[&addr_hash].hash(), storage_root, "storage root mismatch");
+
+        let legacy = state.state_trie.get_rlp::<TrieAccount>(addr_hash.as_slice()).unwrap();
+        let arena = tries.state_trie.get_rlp::<TrieAccount>(addr_hash.as_slice()).unwrap();
+        assert_eq!(legacy, arena, "account lookup mismatch");
+    }
+
+    /// Soundness regression test for the `pre_state_storage_roots` cache.
+    ///
+    /// The psr cache is **untrusted host input** — there's no separate Merkle commitment over
+    /// its bytes. We rely on the executor's final `state_root != block.header.state_root`
+    /// check to catch any tampering. This test makes that property executable: it
+    ///
+    ///   1. Builds an `EthereumState` where one account has non-empty storage_root and
+    ///      another's state will be updated **without** touching its storage (the only path
+    ///      that consults psr).
+    ///   2. Encodes to arena witness, decodes, applies `update`, records the "honest" root.
+    ///   3. Re-encodes, **flips bits in the psr entry's storage_root** for the affected
+    ///      account, decodes the tampered blob, applies the same update, records the
+    ///      "tampered" root.
+    ///   4. Asserts that `honest_root != tampered_root` — i.e., any tamper in psr
+    ///      deterministically changes the computed state root, which the executor's
+    ///      `MismatchedStateRoot` check would surface as a hard error.
+    ///
+    /// If anyone weakens or removes the executor's final check, the soundness chain breaks
+    /// and this test (or its property) needs re-evaluation. See the `SOUNDNESS:` tag at
+    /// `crates/executor/client/src/executor.rs`.
+    #[test]
+    fn psr_tamper_changes_state_root() {
+        // --- Set up: state_trie with two distinguishable accounts ---
+        // `victim_hash` has non-empty storage_root and will be updated this block WITHOUT a
+        // storage change → goes through psr fallback. `bystander_hash` is a second account
+        // so the state_trie is non-trivial and the psr section has multiple entries.
+        let mut storage = MptNode::default();
+        for i in 0..10u64 {
+            storage.insert_rlp(keccak256(i.to_be_bytes()).as_slice(), U256::from(i + 1)).unwrap();
+        }
+        let storage_root = storage.hash();
+        assert_ne!(storage_root, EMPTY_ROOT_HASH, "test setup expects non-empty storage_root");
+
+        let victim_hash = keccak256([1u8; 20]);
+        let bystander_hash = keccak256([2u8; 20]);
+
+        let mut state_trie = MptNode::default();
+        state_trie
+            .insert_rlp(
+                victim_hash.as_slice(),
+                TrieAccount {
+                    nonce: 1,
+                    balance: U256::from(1000u64),
+                    storage_root,
+                    code_hash: keccak256([]),
+                },
+            )
+            .unwrap();
+        state_trie
+            .insert_rlp(
+                bystander_hash.as_slice(),
+                TrieAccount {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    storage_root: EMPTY_ROOT_HASH,
+                    code_hash: keccak256([]),
+                },
+            )
+            .unwrap();
+
+        let mut storage_tries = HashMap::with_hasher(Default::default());
+        storage_tries.insert(victim_hash, storage);
+        let state = EthereumState { state_trie, storage_tries };
+
+        // --- The post-state change we'll apply: bump victim's nonce + balance, but no slot
+        //     writes (so post_state.storages has no entry for victim → psr fallback path). ---
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(
+            victim_hash,
+            Some(reth_primitives_traits::Account {
+                nonce: 2,
+                balance: U256::from(2000u64),
+                bytecode_hash: None,
+            }),
+        );
+
+        // --- 1. Honest path: encode, decode, update, capture root ---
+        let honest_blob = state.to_arena_witness();
+        let bump_honest = Bump::new();
+        let mut honest_tries = ArenaTries::decode(&bump_honest, &honest_blob).unwrap();
+        honest_tries.update(&post_state);
+        let honest_root = honest_tries.state_root();
+
+        // --- 2. Tampered path: same blob, but flip every byte of victim's psr storage_root ---
+        let mut tampered_blob = honest_blob.clone();
+        let (psr_start, psr_count) = locate_psr_section(&tampered_blob);
+        let mut found = false;
+        for i in 0..psr_count {
+            let off = psr_start + i * 64;
+            if &tampered_blob[off..off + 32] == victim_hash.as_slice() {
+                // Flip every byte of the cached storage_root — guarantees a different value.
+                for b in &mut tampered_blob[off + 32..off + 64] {
+                    *b ^= 0xff;
+                }
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "expected victim's hashed_address to appear in the psr section");
+
+        let bump_tampered = Bump::new();
+        let mut tampered_tries = ArenaTries::decode(&bump_tampered, &tampered_blob).unwrap();
+        tampered_tries.update(&post_state);
+        let tampered_root = tampered_tries.state_root();
+
+        // --- 3. The whole soundness argument in one line ---
+        assert_ne!(
+            honest_root, tampered_root,
+            "psr tamper failed to change the computed state root — SOUNDNESS BROKEN. \
+             The executor's `MismatchedStateRoot` check is the only thing that catches a \
+             lying host; if tampering doesn't propagate to the root, the proof would pass with \
+             a forged storage_root. Investigate before shipping.",
+        );
+    }
+
+    /// Re-parse the arena-witness header just enough to find `(psr_start, psr_count)`.
+    /// Mirrors the wire format documented on [`EthereumState::to_arena_witness`].
+    fn locate_psr_section(blob: &[u8]) -> (usize, usize) {
+        let read_u32 = |b: &[u8], pos: &mut usize| -> usize {
+            let v = u32::from_le_bytes(b[*pos..*pos + 4].try_into().unwrap()) as usize;
+            *pos += 4;
+            v
+        };
+
+        let mut pos = 0usize;
+        // state_trie
+        let _state_nodes = read_u32(blob, &mut pos);
+        let state_len = read_u32(blob, &mut pos);
+        pos += state_len;
+        // storage_tries
+        let num_storage = read_u32(blob, &mut pos);
+        for _ in 0..num_storage {
+            pos += 32; // hashed_address
+            let _nodes = read_u32(blob, &mut pos);
+            let len = read_u32(blob, &mut pos);
+            pos += len;
+        }
+        // psr count + start offset
+        let num_psr = read_u32(blob, &mut pos);
+        (pos, num_psr)
     }
 }
 


### PR DESCRIPTION
## Summary
Rebuilds the arena-based state-trie MPT work on top of `main` and makes the two MPT backends selectable via a common `StateTries` trait, defaulting to the audited pointer-based `MptNode`.

`main` independently landed the reth v2.2.0 / revm 38 / drop-Optimism / ethproofs work the original branch also did, so this PR carries forward only the genuinely unique piece — the arena MPT — re-applied cleanly on `main` and made opt-in.

## What's here
- **Arena MPT** (`crates/mpt/src/arena/*`): zero-copy, bumpalo-backed trie + flat-blob witness codec (`EthereumState::to_arena_witness` / `ArenaTries`) with the pre-state storage-root cache. Legacy `EthereumState` is left untouched.
- **`StateTries` trait** (`rsp-mpt`): the common seam, implemented for both `EthereumState` (legacy) and `ArenaTries` (arena).
- **Generic executor**: `TrieDB<'a, T: StateTries>` reads via the trait; a shared `build_trie_db` verifies/constructs it; `BlockExecutor` is generalized over the revm database (backend-agnostic).
- **`arena` cargo feature**: switches the host witness emission (two-item stdin), the guest stdin reading, and the trie backend together. Default is legacy; the host binaries' `build.rs` forwards the feature to the `rsp-client` guest ELF so host and guest always agree.

Usage: `cargo build -p rsp --features arena` (arena host + guest); default builds legacy.

## Validation
- Both guest ELFs build (`cargo prove build`, legacy and `--features arena`); the workspace + all binaries compile both ways; 28 mpt tests (arena roundtrip + psr-cache soundness) and clippy are clean.
- Both backends execute real mainnet blocks correctly end-to-end (clean state root).
- **Same-block execute-only benchmark (mainnet): arena ≈ 30% fewer zkVM cycles.**

| Block | Gas | Legacy cycles | Arena cycles | Reduction |
|---|---:|---:|---:|---:|
| 25531775 | 31.0M | 560,820,262 | 392,981,415 | 29.9% |
| 25531805 | 58.8M | 831,381,334 | 594,611,274 | 28.5% |
| 25531835 | 10.3M | 196,492,699 | 126,359,106 | 35.7% |

## Notes
- The arena MPT is **not yet audited** — that's why legacy remains the default backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)