### PR TITLE
fix(ci): restore cycle tracking metrics

### DIFF
--- a/.github/workflows/cycle-tracking.yml
+++ b/.github/workflows/cycle-tracking.yml
@@ -49,18 +49,19 @@ jobs:
       - name: "Run tests"
         run: |
           export RUST_LOG=info
-          cargo test --release test_in_zkvm -- --exact --nocapture
+          cargo test -p rsp --release --features cycle-tracking --test cycle_count_diff test_in_zkvm -- --exact --nocapture
 
       - name: "Checkout base branch"
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          git checkout origin/${{ github.event.pull_request.base.ref }} -- . ':(exclude)cycle_stats.json'
+          # Use the same benchmark harness and profiling-only feature for both revisions.
+          git checkout origin/${{ github.event.pull_request.base.ref }} -- . ':(exclude)bin/host/cycle_stats.json' ':(exclude)bin/host/Cargo.toml' ':(exclude)bin/host/tests/cycle_count_diff.rs'
 
       - name: "Run tests on base branch"
         id: tests-report
         run: |
           export RUST_LOG=info
-          BASE_BRANCH=1 cargo test  --release test_in_zkvm -- --exact --nocapture
+          BASE_BRANCH=1 cargo test -p rsp --release --features cycle-tracking --test cycle_count_diff test_in_zkvm -- --exact --nocapture
 
       - name: "Add execution report"
         uses: actions/github-script@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deepsize2"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +2890,17 @@ name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
+name = "gecko_profile"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890852c7e1e02bc6758e325d6b1e0236e4fbf21b492f585ce4d4715be54b4c6a"
+dependencies = [
+ "debugid",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "gen_ops"
@@ -7548,13 +7568,16 @@ dependencies = [
  "elf",
  "enum-map",
  "eyre",
+ "gecko_profile",
  "hashbrown 0.14.5",
  "hex",
+ "indicatif",
  "itertools 0.14.0",
  "memmap2",
  "num",
  "object",
  "rrs-succinct",
+ "rustc-demangle",
  "serde",
  "serde_arrays",
  "serde_json",

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -50,6 +50,7 @@ madato = "0.7.0"
 # Select the arena-based (unaudited) MPT backend for both the host witness emission and the
 # `rsp-client` guest ELF (build.rs forwards this to the guest). Default is the legacy MPT.
 arena = ["rsp-host-executor/arena", "rsp-client-executor/arena"]
+cycle-tracking = ["sp1-sdk/profiling"]
 
 [build-dependencies]
 sp1-build.workspace = true

--- a/bin/host/tests/cycle_count_diff.rs
+++ b/bin/host/tests/cycle_count_diff.rs
@@ -20,6 +20,22 @@ use sp1_sdk::{include_elf, CpuProver, ExecutionReport};
 use thousands::Separable;
 use url::Url;
 
+fn required_cycle_count(report: &ExecutionReport, label: &str) -> eyre::Result<u64> {
+    report.cycle_tracker.get(label).copied().ok_or_else(|| {
+        eyre::eyre!(
+            "missing required cycle counter `{label}`; run this test with `--features cycle-tracking`"
+        )
+    })
+}
+
+fn format_diff_percentage(initial: u64, current: u64) -> String {
+    if initial == 0 {
+        "N/A".to_string()
+    } else {
+        format!("{:.2}", (current as f64 - initial as f64) / initial as f64 * 100.0)
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_in_zkvm() {
     // Intialize the environment variables.
@@ -88,41 +104,31 @@ impl ExecutionHooks for Hook {
             Hook::WithCurrentDev => {
                 let stats = Stats {
                     total_cycle_count: execution_report.total_instruction_count(),
-                    deserialize_inputs: execution_report
-                        .cycle_tracker
-                        .get(DESERIALZE_INPUTS)
-                        .copied()
-                        .unwrap_or(0),
-                    initialize_witness_db_cycles_count: execution_report
-                        .cycle_tracker
-                        .get(INIT_WITNESS_DB)
-                        .copied()
-                        .unwrap_or(0),
-                    recover_senders_cycles_count: execution_report
-                        .cycle_tracker
-                        .get(RECOVER_SENDERS)
-                        .copied()
-                        .unwrap_or(0),
-                    header_validation_cycles_count: execution_report
-                        .cycle_tracker
-                        .get(VALIDATE_HEADER)
-                        .copied()
-                        .unwrap_or(0),
-                    block_execution_cycles_count: execution_report
-                        .cycle_tracker
-                        .get(BLOCK_EXECUTION)
-                        .copied()
-                        .unwrap_or(0),
-                    block_validation_cycles_count: execution_report
-                        .cycle_tracker
-                        .get(VALIDATE_EXECUTION)
-                        .copied()
-                        .unwrap_or(0),
-                    state_root_computation_cycles_count: execution_report
-                        .cycle_tracker
-                        .get(COMPUTE_STATE_ROOT)
-                        .copied()
-                        .unwrap_or(0),
+                    deserialize_inputs: required_cycle_count(execution_report, DESERIALZE_INPUTS)?,
+                    initialize_witness_db_cycles_count: required_cycle_count(
+                        execution_report,
+                        INIT_WITNESS_DB,
+                    )?,
+                    recover_senders_cycles_count: required_cycle_count(
+                        execution_report,
+                        RECOVER_SENDERS,
+                    )?,
+                    header_validation_cycles_count: required_cycle_count(
+                        execution_report,
+                        VALIDATE_HEADER,
+                    )?,
+                    block_execution_cycles_count: required_cycle_count(
+                        execution_report,
+                        BLOCK_EXECUTION,
+                    )?,
+                    block_validation_cycles_count: required_cycle_count(
+                        execution_report,
+                        VALIDATE_EXECUTION,
+                    )?,
+                    state_root_computation_cycles_count: required_cycle_count(
+                        execution_report,
+                        COMPUTE_STATE_ROOT,
+                    )?,
                     syscall_count: execution_report.total_syscall_count(),
                     prover_gas: execution_report.gas().unwrap_or_default(),
                 };
@@ -135,12 +141,8 @@ impl ExecutionHooks for Hook {
                     serde_json::from_reader::<_, Stats>(File::open("cycle_stats.json")?)?;
                 let mut output_file = File::options().create(true).append(true).open(path)?;
 
-                let diff_percentage =
-                    |initial: f64, current: f64| (initial - current) / initial * -100_f64;
-
                 let row = |label: &str, initial: u64, current: u64| {
                     let mut r = TableRow::new();
-                    let diff = format!("{:.2}", diff_percentage(initial as f64, current as f64,));
 
                     r.insert(format!("Block {}", executed_block.number), label.to_string());
                     r.insert("Base Branch".to_string(), initial.separate_with_commas());
@@ -149,7 +151,7 @@ impl ExecutionHooks for Hook {
                         "Diff".to_string(),
                         (current as i64 - initial as i64).separate_with_commas(),
                     );
-                    r.insert("Diff (%)".to_string(), diff);
+                    r.insert("Diff (%)".to_string(), format_diff_percentage(initial, current));
                     r
                 };
 
@@ -162,65 +164,37 @@ impl ExecutionHooks for Hook {
                         ),
                         row(
                             "Inputs deserialization",
-                            execution_report
-                                .cycle_tracker
-                                .get(DESERIALZE_INPUTS)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, DESERIALZE_INPUTS)?,
                             current_dev_stats.deserialize_inputs,
                         ),
                         row(
                             "Initialize Witness DB",
-                            execution_report
-                                .cycle_tracker
-                                .get(INIT_WITNESS_DB)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, INIT_WITNESS_DB)?,
                             current_dev_stats.initialize_witness_db_cycles_count,
                         ),
                         row(
                             "Recover Senders",
-                            execution_report
-                                .cycle_tracker
-                                .get(RECOVER_SENDERS)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, RECOVER_SENDERS)?,
                             current_dev_stats.recover_senders_cycles_count,
                         ),
                         row(
                             "Header Validation",
-                            execution_report
-                                .cycle_tracker
-                                .get(VALIDATE_HEADER)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, VALIDATE_HEADER)?,
                             current_dev_stats.header_validation_cycles_count,
                         ),
                         row(
                             "Block Execution",
-                            execution_report
-                                .cycle_tracker
-                                .get(BLOCK_EXECUTION)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, BLOCK_EXECUTION)?,
                             current_dev_stats.block_execution_cycles_count,
                         ),
                         row(
                             "Block Validation",
-                            execution_report
-                                .cycle_tracker
-                                .get(VALIDATE_EXECUTION)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, VALIDATE_EXECUTION)?,
                             current_dev_stats.block_validation_cycles_count,
                         ),
                         row(
                             "State Root Computation",
-                            execution_report
-                                .cycle_tracker
-                                .get(COMPUTE_STATE_ROOT)
-                                .copied()
-                                .unwrap_or_default(),
+                            required_cycle_count(execution_report, COMPUTE_STATE_ROOT)?,
                             current_dev_stats.state_root_computation_cycles_count,
                         ),
                         row(
@@ -261,4 +235,17 @@ struct Stats {
     pub state_root_computation_cycles_count: u64,
     pub syscall_count: u64,
     pub prover_gas: u64,
+}
+
+#[test]
+fn missing_required_cycle_count_is_an_error() {
+    let error = required_cycle_count(&ExecutionReport::default(), DESERIALZE_INPUTS).unwrap_err();
+
+    assert!(error.to_string().contains(DESERIALZE_INPUTS));
+}
+
+#[test]
+fn zero_baseline_percentage_is_not_available() {
+    assert_eq!(format_diff_percentage(0, 0), "N/A");
+    assert_eq!(format_diff_percentage(100, 105), "5.00");
 }


### PR DESCRIPTION
## Summary

- Enable SP1 profiling only for the cycle-tracking workflow.
- Fail when a required phase counter is missing.
- Show `N/A` when a percentage has a zero baseline.

## Motivation

The workflow converted missing phase counters to zero.
This produced invalid `NaN` percentages while the job passed.
SP1 profiling parses the phase markers into the execution report.
Normal builds keep the existing JIT configuration.

## Validation

- Executed block 20,600,000 with the cycle-tracking feature and confirmed all seven phase counters were populated.
- Executed the same block without the feature and confirmed the test failed on the first missing counter.
- Simulated the current and base workflow runs and confirmed the report contained no zero phase counters or `NaN` values.
- Ran format checks, all-target builds, and Clippy with default and cycle-tracking features.
