### PR TITLE
chore(ci): remove cycle tracking bootstrap exclusions

### DIFF
--- a/.github/workflows/cycle-tracking.yml
+++ b/.github/workflows/cycle-tracking.yml
@@ -54,8 +54,7 @@ jobs:
       - name: "Checkout base branch"
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          # Use the same benchmark harness and profiling-only feature for both revisions.
-          git checkout origin/${{ github.event.pull_request.base.ref }} -- . ':(exclude)bin/host/cycle_stats.json' ':(exclude)bin/host/Cargo.toml' ':(exclude)bin/host/tests/cycle_count_diff.rs'
+          git checkout origin/${{ github.event.pull_request.base.ref }} -- . ':(exclude)bin/host/cycle_stats.json'
 
       - name: "Run tests on base branch"
         id: tests-report


### PR DESCRIPTION
## Summary

- Let the base revision use its own manifest and cycle benchmark test.
- Preserve the generated cycle statistics for the base comparison.

## Motivation

The extra exclusions were only required while the base branch lacked the cycle-tracking feature and updated test.
Pull request 188 added both items to the base branch.

## Validation

- Simulated the base checkout and confirmed that it preserved `cycle_stats.json`.
- Confirmed that the base manifest provides the `cycle-tracking` feature.
- Ran the focused cycle metric tests.
